### PR TITLE
fix locusts for test api and suite

### DIFF
--- a/httprunner/locusts.py
+++ b/httprunner/locusts.py
@@ -40,6 +40,7 @@ def gen_locustfile(testcase_file_path):
         "templates",
         "locustfile_template"
     )
+    TestcaseLoader.load_test_dependencies()
     testset = TestcaseLoader.load_test_file(testcase_file_path)
     host = testset.get("config", {}).get("request", {}).get("base_url", "")
 


### PR DESCRIPTION
if use api and suite for testcases, locusts will be failed because  the dependencies are not loaded.

![image](https://user-images.githubusercontent.com/1726587/41755520-76d81ed2-760a-11e8-987c-3498241a8994.png)
