### PR TITLE
文件上传内置功能增加参数配置，修复测试失败时测试报告显示问题

### DIFF
--- a/httprunner/built_in.py
+++ b/httprunner/built_in.py
@@ -43,10 +43,12 @@ def multipart_encoder(field_name, file_path, file_type=None, file_headers=None):
         file_path = os.path.join(os.getcwd(), file_path)
 
     filename = os.path.basename(file_path)
+    if isinstance(file_headers, dict):
+        fields = file_headers.copy()
+    else:
+        fields = {}
     with open(file_path, 'rb') as f:
-        fields = {
-            field_name: (filename, f.read(), file_type)
-        }
+        fields[field_name] = (filename, f.read(), file_type)
 
     return MultipartEncoder(fields)
 

--- a/httprunner/context.py
+++ b/httprunner/context.py
@@ -229,7 +229,6 @@ class Context(object):
             return evaluated_validators
 
         logger.log_info("start to validate.")
-        validate_pass = True
         failures = []
 
         for validator in validators:
@@ -242,13 +241,8 @@ class Context(object):
             try:
                 self._do_validation(evaluated_validator)
             except exceptions.ValidationFailure as ex:
-                validate_pass = False
                 failures.append(str(ex))
 
             evaluated_validators.append(evaluated_validator)
-
-        if not validate_pass:
-            failures_string = "\n".join([failure for failure in failures])
-            raise exceptions.ValidationFailure(failures_string)
 
         return evaluated_validators

--- a/httprunner/runner.py
+++ b/httprunner/runner.py
@@ -214,6 +214,12 @@ class Runner(object):
         # validate
         try:
             self.evaluated_validators = self.context.validate(validators, resp_obj)
+            success_count = 0
+            for validator in self.evaluated_validators:
+                if validator['check_result'] == 'pass':
+                    success_count += 1
+            if not success_count == len(self.evaluated_validators):
+                raise exceptions.ValidationFailure
         except (exceptions.ParamsError, exceptions.ValidationFailure, exceptions.ExtractFailure):
             # log request
             err_req_msg = "request: \n"


### PR DESCRIPTION
1.内置文件上传模块无法增加 multipart/form-data 参数，如：
```
--HttpRunnerFormDataBoundary1535614542
Content-Disposition: form-data; name="key"

value
```

2.修复接口测试用例失败报告显示问题