### PR TITLE
bugfix: base url missed

### DIFF
--- a/httprunner/runner.py
+++ b/httprunner/runner.py
@@ -47,7 +47,7 @@ class Runner(object):
             http_client_session (instance): requests.Session(), or locust.client.Session() instance.
 
         """
-        base_url = config.get("base_url")
+        base_url = config.get("request").get("base_url")
         self.verify = config.get("verify", True)
         self.output = config.get("output", [])
         self.functions = functions


### PR DESCRIPTION
Error “base url missed” occured when execute case demo-quickstart-4.json from HttpRunner's documentation.
Structure of config expected by runner.py is not inconsistent with the reality.

close #496