### PR TITLE
2.1.2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - pip install pipenv --upgrade-strategy=only-if-needed
   - pipenv install --dev --skip-lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 
 - support new variable notation ${var}
 - use \$\$ to escape \$ notation
+- add Python 3.7 for travis CI
 
 **Bugfixes**
 
 - match duplicate variable/function in single raw string
 - escape '{' and '}' notation in raw string
+- print_info: TypeError when value is None
+- display api name when running api as testcase
 
 ## 2.1.1 (2019-04-11)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 2.1.2 (2019-04-17)
+
+**Features**
+
+- use \$\$ to escape \$ notation
+
+**Bugfixes**
+
+- match duplicate variable/function in single raw string
+- escape '{' and '}' notation in raw string
+
 ## 2.1.1 (2019-04-11)
 
 **Features**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 **Features**
 
+- support new variable notation ${var}
 - use \$\$ to escape \$ notation
 
 **Bugfixes**

--- a/httprunner/__about__.py
+++ b/httprunner/__about__.py
@@ -1,7 +1,7 @@
 __title__ = 'HttpRunner'
 __description__ = 'One-stop solution for HTTP(S) testing.'
 __url__ = 'https://github.com/HttpRunner/HttpRunner'
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 __author__ = 'debugtalk'
 __author_email__ = 'mail@debugtalk.com'
 __license__ = 'Apache-2.0'

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -458,11 +458,15 @@ class LazyString(object):
         """
         self._args = []
 
+        def escape_braces(origin_string):
+            return origin_string.replace("{", "{{").replace("}", "}}")
+
         try:
             match_start_position = raw_string.index("$", 0)
-            self._string = raw_string[0:match_start_position]
+            begin_string = raw_string[0:match_start_position]
+            self._string = escape_braces(begin_string)
         except ValueError:
-            self._string = raw_string
+            self._string = escape_braces(raw_string)
             return
 
         while match_start_position < len(raw_string):
@@ -518,9 +522,7 @@ class LazyString(object):
                 # break while loop
                 match_start_position = len(raw_string)
 
-            remain_string = remain_string.replace("{", "{{")
-            remain_string = remain_string.replace("}", "}}")
-            self._string += remain_string
+            self._string += escape_braces(remain_string)
 
     def __repr__(self):
         return "LazyString({})".format(self.raw_string)

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -7,6 +7,8 @@ import re
 from httprunner import exceptions, utils, validator
 from httprunner.compat import basestring, builtin_str, numeric_types, str
 
+# use $$ to escape $ notation
+dolloar_regex_compile = re.compile(r"\$\$")
 # TODO: change variable notation from $var to {{var}}
 # $var_1
 variable_regex_compile = re.compile(r"\$(\w+)")
@@ -447,7 +449,16 @@ class LazyString(object):
 
         while match_start_position < len(raw_string):
 
-            # Notice: functions must be handled before variables
+            # Notice: notation priority
+            # $$ > ${func($a, $b)} > $var
+
+            # search $$
+            dollar_match = dolloar_regex_compile.match(raw_string, match_start_position)
+            if dollar_match:
+                match_start_position = dollar_match.end()
+                self._string += "$"
+                continue
+
             # search function like ${func($a, $b)}
             func_match = function_regex_compile.match(raw_string, match_start_position)
             if func_match:

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -483,10 +483,15 @@ class LazyString(object):
             try:
                 # find next $ location
                 match_start_position = raw_string.index("$", curr_position+1)
-                self._string += raw_string[curr_position:match_start_position]
+                remain_string = raw_string[curr_position:match_start_position]
             except ValueError:
-                self._string += raw_string[curr_position:]
-                break
+                remain_string = raw_string[curr_position:]
+                # break while loop
+                match_start_position = len(raw_string)
+
+            remain_string = remain_string.replace("{", "{{")
+            remain_string = remain_string.replace("}", "}}")
+            self._string += remain_string
 
     def __repr__(self):
         return "LazyString({})".format(self.raw_string)

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -451,11 +451,11 @@ class LazyString(object):
             # search function like ${func($a, $b)}
             func_match = function_regex_compile.match(raw_string, match_start_position)
             if func_match:
-                function_meta = parse_function_params(func_match[1])
+                function_meta = parse_function_params(func_match.group(1))
                 function_meta = {
-                    "func_name": func_match[1]
+                    "func_name": func_match.group(1)
                 }
-                function_meta.update(parse_function_params(func_match[2]))
+                function_meta.update(parse_function_params(func_match.group(2)))
                 lazy_func = LazyFunction(
                     function_meta,
                     self.functions_mapping,

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -31,18 +31,32 @@ def parse_string_value(str_value):
         return str_value
 
 
-def is_variable_exist(content):
+def is_var_or_func_exist(content):
+    """ check if variable or function exist
+    """
     if not isinstance(content, basestring):
         return False
 
-    return True if variable_regex_compile.search(content) else False
-
-
-def is_function_exist(content):
-    if not isinstance(content, basestring):
+    try:
+        match_start_position = content.index("$", 0)
+    except ValueError:
         return False
 
-    return True if function_regex_compile.search(content) else False
+    while match_start_position < len(content):
+        dollar_match = dolloar_regex_compile.match(content, match_start_position)
+        if dollar_match:
+            match_start_position = dollar_match.end()
+            continue
+
+        func_match = function_regex_compile.match(content, match_start_position)
+        if func_match:
+            return True
+
+        var_match = variable_regex_compile.match(content, match_start_position)
+        if var_match:
+            return True
+
+        return False
 
 
 def regex_findall_variables(content):
@@ -580,7 +594,7 @@ def prepare_lazy_data(content, functions_mapping=None, check_variables_set=None,
 
     elif isinstance(content, basestring):
         # content is in string format here
-        if not (is_variable_exist(content) or is_function_exist(content)):
+        if not is_var_or_func_exist(content):
             # content is neither variable nor function
             return content
 

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -596,7 +596,9 @@ def prepare_lazy_data(content, functions_mapping=None, check_variables_set=None,
         # content is in string format here
         if not is_var_or_func_exist(content):
             # content is neither variable nor function
-            return content
+            # replace $$ notation with $ and consider it as normal char.
+            # e.g. abc => abc, abc$$def => abc$def, abc$$$$def$$h => abc$$def$h
+            return content.replace("$$", "$")
 
         functions_mapping = functions_mapping or {}
         check_variables_set = check_variables_set or set()

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -1254,6 +1254,9 @@ def parse_tests(tests_mapping):
             # encapsulate api as a testcase
             for api_content in tests_mapping["apis"]:
                 testcase = {
+                    "config": {
+                        "name": api_content.get("name")
+                    },
                     "teststeps": [api_content]
                 }
                 parsed_testcase = _parse_testcase(testcase, project_mapping)

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -458,6 +458,7 @@ class LazyString(object):
                 self.check_variables_set
             )
             args_mapping[match_start_position] = lazy_func
+            match_start_position += len(func_str)
 
         # search variable like $var
         var_match_list = regex_findall_variables(self._string)
@@ -474,6 +475,7 @@ class LazyString(object):
             # self._string = self._string.replace("}", "}}")
             self._string = self._string.replace(var, "{}", 1)
             args_mapping[match_start_position] = var_name
+            match_start_position += len(var)
 
         self._args = [args_mapping[key] for key in sorted(args_mapping.keys())]
 

--- a/httprunner/utils.py
+++ b/httprunner/utils.py
@@ -385,6 +385,8 @@ def print_info(info_mapping):
             continue
         elif isinstance(value, (dict, list)):
             value = json.dumps(value)
+        elif value is None:
+            value = "None"
 
         if is_py2:
             if isinstance(key, unicode):

--- a/tests/httpbin/api/get_headers.yml
+++ b/tests/httpbin/api/get_headers.yml
@@ -1,9 +1,11 @@
 
-name: headers
+name: get headers
 base_url: http://httpbin.org
+variables:
+    expected_status_code: 200
 request:
     url: /headers
     method: GET
 validate:
-    - eq: ["status_code", 200]
+    - eq: ["status_code", $expected_status_code]
     - eq: [content.headers.Host, "httpbin.org"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -326,21 +326,44 @@ class TestParserBasic(unittest.TestCase):
         self.assertEqual(var.to_value(variables_mapping), "ABCabc/123abc/456")
 
         var = parser.LazyString("ABC$var_1{", functions_mapping, check_variables_set)
-        self.assertEqual(var._string, "ABC{}{")
+        self.assertEqual(var._string, "ABC{}{{")
         self.assertEqual(var._args, ["var_1"])
-        # self.assertEqual(var.to_value(variables_mapping), "ABCabc{")
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc{")
+
+        var = parser.LazyString("ABC$var_1}", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC{}}}")
+        self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc}")
 
         var = parser.LazyString("ABC$$var_1{", functions_mapping, check_variables_set)
-        self.assertEqual(var._string, "ABC${}{")
+        self.assertEqual(var._string, "ABC${}{{")
         self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABC$abc{")
 
         var = parser.LazyString("ABC$var_1${", functions_mapping, check_variables_set)
-        self.assertEqual(var._string, "ABC{}${")
+        self.assertEqual(var._string, "ABC{}${{")
         self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc${")
 
         var = parser.LazyString("ABC$var_1${a", functions_mapping, check_variables_set)
-        self.assertEqual(var._string, "ABC{}${a")
+        self.assertEqual(var._string, "ABC{}${{a")
         self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc${a")
+
+        var = parser.LazyString("ABC$var_1$}a", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC{}$}}a")
+        self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc$}a")
+
+        var = parser.LazyString("ABC$var_1}{a", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC{}}}{{a")
+        self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc}{a")
+
+        var = parser.LazyString("ABC$var_1{}a", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC{}{{}}a")
+        self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc{}a")
 
         var = parser.LazyString("ABC$var_1/$var_2/$var_1", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC{}/{}/{}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -305,6 +305,16 @@ class TestParserBasic(unittest.TestCase):
         self.assertEqual(var._args, ["var_1"])
         self.assertEqual(var.to_value(variables_mapping), "ABCabc{")
 
+        var = parser.LazyString("{ABC$var_1{}a}", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "{{ABC{}{{}}a}}")
+        self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "{ABCabc{}a}")
+
+        var = parser.LazyString("AB{C$var_1{}a}", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "AB{{C{}{{}}a}}")
+        self.assertEqual(var._args, ["var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "AB{Cabc{}a}")
+
         # }
         var = parser.LazyString("ABC$var_1}", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC{}}}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -320,6 +320,11 @@ class TestParserBasic(unittest.TestCase):
         self.assertEqual(var._args, ["var_1"])
         self.assertEqual(var.to_value(variables_mapping), "ABCabc$")
 
+        var = parser.LazyString("ABC$var_1/123$var_1/456", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC{}/123{}/456")
+        self.assertEqual(var._args, ["var_1", "var_1"])
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc/123abc/456")
+
         var = parser.LazyString("ABC$var_1{", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC{}{")
         self.assertEqual(var._args, ["var_1"])
@@ -360,6 +365,27 @@ class TestParserBasic(unittest.TestCase):
         var = parser.LazyString("ABC${func1($var_1, $var_3)}$var_5", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC{}{}")
         self.assertEqual(var.to_value(variables_mapping), "ABCabc123True")
+
+        var = parser.LazyString(
+            "ABC${func1($var_1, $var_3)}--${func1($var_1, $var_3)}",
+            functions_mapping,
+            check_variables_set
+        )
+        self.assertEqual(var._string, "ABC{}--{}")
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc123--abc123")
+
+        var = parser.LazyString("ABC${func1($var_1, $var_3)}$var_1", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC{}{}")
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc123abc")
+
+        # TODO: fix
+        # var = parser.LazyString(
+        #     "ABC${func1($var_1, $var_3)}$var_1--${func1($var_1, $var_3)}$var_1",
+        #     functions_mapping,
+        #     check_variables_set
+        # )
+        # self.assertEqual(var._string, "ABC{}{}--{}{}")
+        # self.assertEqual(var.to_value(variables_mapping), "ABCabc123abc--abc123abc")
 
         var = parser.LazyString("ABC${func1($var_1, $var_3)}DE$var_4", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC{}DE{}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -730,8 +730,8 @@ class TestParserBasic(unittest.TestCase):
         }
         prepared_variables = parser.prepare_lazy_data(variables, functions, variables.keys())
         parsed_testcase = parser.parse_variables_mapping(prepared_variables)
-        self.assertEqual(parsed_testcase["varB"], "456$$0")
-        self.assertEqual(parsed_testcase["varA"], "123456$$0")
+        self.assertEqual(parsed_testcase["varA"], "123456$0")
+        self.assertEqual(parsed_testcase["varB"], "456$0")
         self.assertEqual(parsed_testcase["varC"], 3)
 
     def test_prepare_lazy_data(self):
@@ -770,6 +770,29 @@ class TestParserBasic(unittest.TestCase):
                 variables.keys()
             )
 
+    def test_prepare_lazy_data_dual_dollar(self):
+        variables = {
+            "num0": 123,
+            "var1": "abc$$num0",
+            "var2": "abc$$$num0",
+            "var3": "abc$$$$num0",
+        }
+        functions = {
+            "sum_two": sum_two
+        }
+        prepared_variables = parser.prepare_lazy_data(
+            variables,
+            functions,
+            variables.keys()
+        )
+        self.assertEqual(prepared_variables["var1"], "abc$num0")
+        self.assertIsInstance(prepared_variables["var2"], parser.LazyString)
+        self.assertEqual(prepared_variables["var3"], "abc$$num0")
+
+        parsed_variables = parser.parse_variables_mapping(prepared_variables)
+        self.assertEqual(parsed_variables["var1"], "abc$num0")
+        self.assertEqual(parsed_variables["var2"], "abc$123")
+        self.assertEqual(parsed_variables["var3"], "abc$$num0")
 
 class TestParser(unittest.TestCase):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -378,14 +378,13 @@ class TestParserBasic(unittest.TestCase):
         self.assertEqual(var._string, "ABC{}{}")
         self.assertEqual(var.to_value(variables_mapping), "ABCabc123abc")
 
-        # TODO: fix
-        # var = parser.LazyString(
-        #     "ABC${func1($var_1, $var_3)}$var_1--${func1($var_1, $var_3)}$var_1",
-        #     functions_mapping,
-        #     check_variables_set
-        # )
-        # self.assertEqual(var._string, "ABC{}{}--{}{}")
-        # self.assertEqual(var.to_value(variables_mapping), "ABCabc123abc--abc123abc")
+        var = parser.LazyString(
+            "ABC${func1($var_1, $var_3)}$var_1--${func1($var_1, $var_3)}$var_1",
+            functions_mapping,
+            check_variables_set
+        )
+        self.assertEqual(var._string, "ABC{}{}--{}{}")
+        self.assertEqual(var.to_value(variables_mapping), "ABCabc123abc--abc123abc")
 
         var = parser.LazyString("ABC${func1($var_1, $var_3)}DE$var_4", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC{}DE{}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -336,9 +336,19 @@ class TestParserBasic(unittest.TestCase):
         self.assertEqual(var.to_value(variables_mapping), "ABCabc}")
 
         var = parser.LazyString("ABC$$var_1{", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC$var_1{{")
+        self.assertEqual(var._args, [])
+        self.assertEqual(var.to_value(variables_mapping), "ABC$var_1{")
+
+        var = parser.LazyString("ABC$$$var_1{", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC${}{{")
         self.assertEqual(var._args, ["var_1"])
         self.assertEqual(var.to_value(variables_mapping), "ABC$abc{")
+
+        var = parser.LazyString("ABC$$$$var_1{", functions_mapping, check_variables_set)
+        self.assertEqual(var._string, "ABC$$var_1{{")
+        self.assertEqual(var._args, [])
+        self.assertEqual(var.to_value(variables_mapping), "ABC$$var_1{")
 
         var = parser.LazyString("ABC$var_1${", functions_mapping, check_variables_set)
         self.assertEqual(var._string, "ABC{}${{")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -263,3 +263,15 @@ class TestUtils(ApiServerUnittest):
         parameters_content_list = []
         product_list = utils.gen_cartesian_product(*parameters_content_list)
         self.assertEqual(product_list, [])
+
+    def test_print_info(self):
+        info_mapping = {
+            "a": 1,
+            "t": (1, 2),
+            "b": {
+                "b1": 123
+            },
+            "c": None,
+            "d": [4, 5]
+        }
+        utils.print_info(info_mapping)

--- a/tests/testsuites/create_users_with_parameters.yml
+++ b/tests/testsuites/create_users_with_parameters.yml
@@ -1,5 +1,5 @@
 config:
-    name: create users with uid
+    name: create users with parameters
     variables:
         device_sn: ${gen_random_string(15)}
     base_url: "http://127.0.0.1:5000"


### PR DESCRIPTION

**Features**

- support new variable notation ${var}
- use \$\$ to escape \$ notation
- add Python 3.7 for travis CI

**Bugfixes**

- match duplicate variable/function in single raw string
- escape '{' and '}' notation in raw string
- print_info: TypeError when value is None
- display api name when running api as testcase
