### PR TITLE
2.2.2: rename keyword output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 - `extract` is used to replace `output` when passing former teststep's (as a testcase) export value to next teststep
+- `export` is used to replace `output` in testcase config
 
 ## 2.2.1 (2019-06-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.2.2 (2019-06-26)
+
+**Features**
+
+- `extract` is used to replace `output` when passing former teststep's (as a testcase) export value to next teststep
+
 ## 2.2.1 (2019-06-25)
 
 **Features**

--- a/httprunner/__about__.py
+++ b/httprunner/__about__.py
@@ -1,7 +1,7 @@
 __title__ = 'HttpRunner'
 __description__ = 'One-stop solution for HTTP(S) testing.'
 __url__ = 'https://github.com/HttpRunner/HttpRunner'
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 __author__ = 'debugtalk'
 __author_email__ = 'mail@debugtalk.com'
 __license__ = 'Apache-2.0'

--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -942,7 +942,13 @@ def __prepare_testcase_tests(tests, config, project_mapping, session_variables_s
         if "testcase_def" in test_dict:
             # test_dict is nested testcase
 
-            if "output" in test_dict:
+            # pass former teststep's (as a testcase) export value to next teststep
+            # Since V2.2.2, `extract` is used to replace `output`,
+            # `output` is also kept for compatibility
+            if "extract" in test_dict:
+                session_variables_set |= set(test_dict["extract"])
+            elif "output" in test_dict:
+                # kept for compatibility
                 session_variables_set |= set(test_dict["output"])
 
             # 2, testcase test_dict => testcase_def config

--- a/httprunner/runner.py
+++ b/httprunner/runner.py
@@ -61,7 +61,7 @@ class Runner(object):
 
         """
         self.verify = config.get("verify", True)
-        self.output = config.get("output", [])
+        self.export = config.get("export") or config.get("output", [])
         self.validation_results = []
         config_variables = config.get("variables", {})
 
@@ -327,7 +327,7 @@ class Runner(object):
                 self.meta_datas.append(_meta_datas)
 
         self.session_context.update_session_variables(
-            test_runner.extract_output(test_runner.output)
+            test_runner.export_variables(test_runner.export)
         )
 
     def run_test(self, test_dict):
@@ -382,8 +382,8 @@ class Runner(object):
             finally:
                 self.meta_datas = self.__get_test_data()
 
-    def extract_output(self, output_variables_list):
-        """ extract output variables
+    def export_variables(self, output_variables_list):
+        """ export current testcase variables
         """
         variables_mapping = self.session_context.session_variables_mapping
 
@@ -391,7 +391,7 @@ class Runner(object):
         for variable in output_variables_list:
             if variable not in variables_mapping:
                 logger.log_warning(
-                    "variable '{}' can not be found in variables mapping, failed to output!"\
+                    "variable '{}' can not be found in variables mapping, failed to export!"\
                         .format(variable)
                 )
                 continue

--- a/httprunner/utils.py
+++ b/httprunner/utils.py
@@ -328,7 +328,7 @@ def extend_variables(raw_variables, override_variables):
 
 
 def get_testcase_io(testcase):
-    """ get and print testcase input(variables) and output.
+    """ get and print testcase input(variables) and output(export).
 
     Args:
         testcase (unittest.suite.TestSuite): corresponding to one YAML/JSON file, it has been set two attributes:
@@ -340,12 +340,13 @@ def get_testcase_io(testcase):
     """
     test_runner = testcase.runner
     variables = testcase.config.get("variables", {})
-    output_list = testcase.config.get("output", [])
-    output_mapping = test_runner.extract_output(output_list)
+    output_list = testcase.config.get("export") \
+        or testcase.config.get("output", [])
+    export_mapping = test_runner.export_variables(output_list)
 
     return {
         "in": variables,
-        "out": output_mapping
+        "out": export_mapping
     }
 
 

--- a/tests/data/demo_testcase_layer.yml
+++ b/tests/data/demo_testcase_layer.yml
@@ -6,7 +6,7 @@
         os_platform: 'ios'
         app_version: '2.8.6'
     base_url: ${get_base_url()}
-    output:
+    export:
         - token
 
 - test:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,7 +93,7 @@ class TestHttpRunner(ApiServerUnittest):
                         "var1": "abc",
                         "var2": "def"
                     },
-                    "output": ["status_code", "req_data"]
+                    "export": ["status_code", "req_data"]
                 },
                 "teststeps": [
                     {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -636,23 +636,28 @@ class TestApi(ApiServerUnittest):
         self.assertEqual(len(tests_results[0][1].records), 2)
 
     def test_testcase_complex_run_suite(self):
-        testcase_path = "tests/testcases/create_user.yml"
-        tests_mapping = loader.load_tests(testcase_path)
-        testcases = parser.parse_tests(tests_mapping)
-        runner = HttpRunner()
-        test_suite = runner._add_tests(testcases)
-        tests_results = runner._run_suite(test_suite)
-        self.assertEqual(len(tests_results[0][1].records), 2)
+        for testcase_path in [
+            "tests/testcases/create_user.yml",
+            "tests/testcases/create_user.v2.yml",
+            "tests/testcases/create_user.json",
+            "tests/testcases/create_user.v2.json"
+        ]:
+            tests_mapping = loader.load_tests(testcase_path)
+            testcases = parser.parse_tests(tests_mapping)
+            runner = HttpRunner()
+            test_suite = runner._add_tests(testcases)
+            tests_results = runner._run_suite(test_suite)
+            self.assertEqual(len(tests_results[0][1].records), 2)
 
-        results = tests_results[0][1]
-        self.assertEqual(
-            results.records[0]["name"],
-            "setup and reset all (override) for TESTCASE_CREATE_XXX."
-        )
-        self.assertEqual(
-            results.records[1]["name"],
-            "create user and check result."
-        )
+            results = tests_results[0][1]
+            self.assertEqual(
+                results.records[0]["name"],
+                "setup and reset all (override) for TESTCASE_CREATE_XXX."
+            )
+            self.assertEqual(
+                results.records[1]["name"],
+                "create user and check result."
+            )
 
     def test_testsuite_loader(self):
         testcase_path = "tests/testsuites/create_users.yml"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -271,8 +271,7 @@ class TestSuiteLoader(unittest.TestCase):
             "testcase": "testcases/setup.yml",
             "variables": [
                 {"device_sn": "$device_sn"}
-            ],
-            "output": ["token", "device_sn"]
+            ]
         }
         testcase = loader.load_teststep(raw_test)
         self.assertEqual(

--- a/tests/testcases/create_user.json
+++ b/tests/testcases/create_user.json
@@ -1,0 +1,34 @@
+[
+  {
+    "config": {
+      "id": "create_user",
+      "variables": {
+        "device_sn": "TESTCASE_CREATE_XXX",
+        "uid": 9001
+      },
+      "output": [
+        "session_token"
+      ],
+      "base_url": "http://127.0.0.1:5000",
+      "name": "create user and check result."
+    }
+  },
+  {
+    "test": {
+      "testcase": "testcases/setup.yml",
+      "extract": [
+        "session_token"
+      ],
+      "name": "setup and reset all (override) for $device_sn."
+    }
+  },
+  {
+    "test": {
+      "testcase": "testcases/deps/check_and_create.yml",
+      "variables": {
+        "token": "$session_token"
+      },
+      "name": "create user and check result."
+    }
+  }
+]

--- a/tests/testcases/create_user.v2.json
+++ b/tests/testcases/create_user.v2.json
@@ -1,0 +1,30 @@
+{
+  "config": {
+    "id": "create_user",
+    "variables": {
+      "device_sn": "TESTCASE_CREATE_XXX",
+      "uid": 9001
+    },
+    "output": [
+      "session_token"
+    ],
+    "base_url": "http://127.0.0.1:5000",
+    "name": "create user and check result."
+  },
+  "teststeps": [
+    {
+      "testcase": "testcases/setup.yml",
+      "extract": [
+        "session_token"
+      ],
+      "name": "setup and reset all (override) for $device_sn."
+    },
+    {
+      "testcase": "testcases/deps/check_and_create.yml",
+      "variables": {
+        "token": "$session_token"
+      },
+      "name": "create user and check result."
+    }
+  ]
+}

--- a/tests/testcases/create_user.v2.yml
+++ b/tests/testcases/create_user.v2.yml
@@ -12,9 +12,8 @@ teststeps:
 -
     name: setup and reset all (override) for $device_sn.
     testcase: testcases/setup.yml
-    output:
+    extract:
         - session_token
-
 -
     name: create user and check result.
     variables:

--- a/tests/testcases/create_user.v2.yml
+++ b/tests/testcases/create_user.v2.yml
@@ -5,7 +5,7 @@ config:
     variables:
         uid: 9001
         device_sn: "TESTCASE_CREATE_XXX"
-    output:
+    export:
         - session_token
 
 teststeps:

--- a/tests/testcases/create_user.yml
+++ b/tests/testcases/create_user.yml
@@ -6,7 +6,7 @@
     variables:
         uid: 9001
         device_sn: "TESTCASE_CREATE_XXX"
-    output:
+    export:
         - session_token
 
 - test:

--- a/tests/testcases/create_user.yml
+++ b/tests/testcases/create_user.yml
@@ -12,7 +12,7 @@
 - test:
     name: setup and reset all (override) for $device_sn.
     testcase: testcases/setup.yml
-    output:
+    extract:
         - session_token
 
 - test:

--- a/tests/testcases/setup.v2.yml
+++ b/tests/testcases/setup.v2.yml
@@ -8,7 +8,7 @@ config:
         app_version: '2.8.6'
     base_url: "http://127.0.0.1:5000"
     verify: False
-    output:
+    export:
         - session_token
 
 teststeps:

--- a/tests/testcases/setup.yml
+++ b/tests/testcases/setup.yml
@@ -8,7 +8,7 @@
         app_version: '2.8.6'
     base_url: "http://127.0.0.1:5000"
     verify: False
-    output:
+    export:
         - session_token
 
 - test:


### PR DESCRIPTION

- feat: 'extract' is used to replace 'output' when passing former teststep's (as a testcase) export value to next teststep
- feat: 'export' is used to replace 'output' in testcase config