### PR TITLE
Add jsonpath extract besides delimeter, regex

### DIFF
--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -242,7 +242,9 @@ class ResponseObject(object):
 
         msg = "extract: {}".format(field)
 
-        if text_extractor_regexp_compile.match(field):
+        if field.startswith("$"):
+            value = self._extract_field_with_jsonpath(field)
+        elif text_extractor_regexp_compile.match(field):
             value = self._extract_field_with_regex(field)
         else:
             value = self._extract_field_with_delimiter(field)

--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -2,11 +2,13 @@
 
 import json
 import re
+import jsonpath
 
 from httprunner import exceptions, logger, utils
 from httprunner.compat import OrderedDict, basestring, is_py2
 from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
+
 
 text_extractor_regexp_compile = re.compile(r".*\(.*\).*")
 
@@ -38,6 +40,35 @@ class ResponseObject(object):
             logger.log_error(err_msg)
             raise exceptions.ParamsError(err_msg)
 
+    def _extract_field_with_jsonpath(self, field):
+        """
+        JSONPath Docs: https://goessner.net/articles/JsonPath/
+        For example, response body like below:
+        {
+            "code": 200,
+            "data": {
+                "items": [{
+                        "id": 1,
+                        "name": "Bob"
+                    },
+                    {
+                        "id": 2,
+                        "name": "James"
+                    }
+                ]
+            },
+            "message": "操作成功"
+        }
+
+        :param field:  Jsonpath expression, e.g. 1)$.code   2) $..items.*.id
+        :return:       A list that extracted from json repsonse example.    1) [200]   2) [1, 2]
+        """
+        result = jsonpath.jsonpath(self.parsed_body(), field)
+        if result:
+            return result
+        else:
+            raise exceptions.ExtractFailure("\tjsonpath {} get nothing\n".format(field))
+            
     def _extract_field_with_regex(self, field):
         """ extract field from response content with regex.
             requests.Response body could be json or html text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ colorama = "^0.4.1"
 colorlog = "^4.0"
 filetype = "^1.0"
 future = { version = "^0.17.1", python = "~2.7" }
+jsonpath = "^0.82"
 
 [tool.poetry.dev-dependencies]
 flask = "<1.0.0"


### PR DESCRIPTION
在过去一年多，我们团队使用HttpRunner作为基础框架，二次开发了一套接口测试框架。JSONPath在我们实际接口测试中使用非常频繁和实用，因为很多Json数据的校验场景比较复杂，例如校验返回值JSON的某个数组结构中，输入和输出的包含/集合关系等，同时，利用JsonPath的条件表达式，如$.store.book[?(@.price < 10)].title，可以快速找出符合条件的数据。这样，写测试用例的校验和取值的表现力就更强了！

For your reference(供参考)：
https://goessner.net/articles/JsonPath/

