### PR TITLE
修复测试报告duration统计错误

### DIFF
--- a/httprunner/report.py
+++ b/httprunner/report.py
@@ -62,8 +62,8 @@ def get_summary(result):
         - summary["stat"]["unexpectedSuccesses"]
 
     summary["time"] = {
-         'start_at': result.start_at
-        # 'duration': result.duration
+        'start_at': result.start_at,
+        'duration': result.duration
     }
     summary["records"] = result.records
 

--- a/httprunner/report.py
+++ b/httprunner/report.py
@@ -62,8 +62,8 @@ def get_summary(result):
         - summary["stat"]["unexpectedSuccesses"]
 
     summary["time"] = {
-        'start_at': result.start_at,
-        'duration': result.duration
+         'start_at': result.start_at
+        # 'duration': result.duration
     }
     summary["records"] = result.records
 
@@ -82,8 +82,9 @@ def aggregate_stat(origin_stat, new_stat):
         if key not in origin_stat:
             origin_stat[key] = new_stat[key]
         elif key == "start_at":
-            # start datetime
+            # start datetime , duration=current_time - min(stat_at)
             origin_stat[key] = min(origin_stat[key], new_stat[key])
+            origin_stat["duration"] = time.time() - origin_stat[key]
         else:
             origin_stat[key] += new_stat[key]
 


### PR DESCRIPTION
对应的 issue ：#707

修复说明：
2.2.6版本的代码，存在多个用例集时，duration计算方法如下：
1.算出各个testcase的start_at
2.**所有testcase结束后计算duration**
3.将各duration累加

可以明显看到，第二步存在问题 
```python
@property      #这里计算的duration周期是错的
def duration(self):
    return time.time() - self.start_at
```

修正方式：
多用例集的情况下，直接取结束时间，减去最小开始时间
```python
for key in new_stat:
    if key not in origin_stat:
        origin_stat[key] = new_stat[key]
    elif key == "start_at":
        # start datetime , duration=current_time - min(stat_at)
        origin_stat[key] = min(origin_stat[key], new_stat[key])
        origin_stat["duration"] = time.time() - origin_stat[key]
    else:
        origin_stat[key] += new_stat[key]
```
