### PR TITLE
bug fix: 当使用.csv文件内容来做数据驱动测试时, length_xxx函数都会失败

### DIFF
--- a/httprunner/built_in.py
+++ b/httprunner/built_in.py
@@ -144,27 +144,32 @@ def string_equals(check_value, expect_value):
 
 def length_equals(check_value, expect_value):
     assert isinstance(expect_value, integer_types)
-    assert len(check_value) == expect_value
+    expect_len = _cast_to_int(expect_value)
+    assert len(check_value) == expect_len
 
 
 def length_greater_than(check_value, expect_value):
     assert isinstance(expect_value, integer_types)
-    assert len(check_value) > expect_value
+    expect_len = _cast_to_int(expect_value)
+    assert len(check_value) > expect_len
 
 
 def length_greater_than_or_equals(check_value, expect_value):
     assert isinstance(expect_value, integer_types)
-    assert len(check_value) >= expect_value
+    expect_len = _cast_to_int(expect_value)
+    assert len(check_value) >= expect_len
 
 
 def length_less_than(check_value, expect_value):
     assert isinstance(expect_value, integer_types)
-    assert len(check_value) < expect_value
+    expect_len = _cast_to_int(expect_value)
+    assert len(check_value) < expect_len
 
 
 def length_less_than_or_equals(check_value, expect_value):
     assert isinstance(expect_value, integer_types)
-    assert len(check_value) <= expect_value
+    expect_len = _cast_to_int(expect_value)
+    assert len(check_value) <= expect_len
 
 
 def contains(check_value, expect_value):
@@ -204,3 +209,9 @@ def startswith(check_value, expect_value):
 
 def endswith(check_value, expect_value):
     assert builtin_str(check_value).endswith(builtin_str(expect_value))
+
+def _cast_to_int(expect_value):
+    try:
+        return int(expect_value)
+    except Exception:
+        raise AssertionError("%r can't cast to int" % str(expect_value))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,6 +80,11 @@ class TestUtils(ApiServerUnittest):
         functions_mapping["not_equals"](123, "123")
 
         functions_mapping["length_equals"]("123", 3)
+        # Because the Numbers in a CSV file are by default treated as strings, 
+        # you need to convert them to Numbers, and we'll test that out here.
+        functions_mapping["length_equals"]("123", '3')
+        with self.assertRaises(AssertionError):
+            functions_mapping["length_equals"]("123", 'abc')
         functions_mapping["length_greater_than"]("123", 2)
         functions_mapping["length_greater_than_or_equals"]("123", 3)
 


### PR DESCRIPTION
添加了个私有函数来将期待的长度转化为int类型