### PR TITLE
2.4.4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## 2.4.4 (2019-12-17)
 
+**Added**
+
+- feat: add keyword `body` to reference response body
+
 **Changed**
 
 - refactor: dumps request/response headers, display indented json in html report
 - refactor: dumps request/response body if it is in json format, display indented json in html report
+- change: unify response field(content/json/text) to `body` in html report
 
 ## 2.4.3 (2019-12-16)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Changed**
 
-- refactor: dumps request and response headers/body, display indented json in report
+- refactor: dumps request/response headers, display indented json in html report
+- refactor: dumps request/response body if it is in json format, display indented json in html report
 
 ## 2.4.3 (2019-12-16)
 

--- a/httprunner/__init__.py
+++ b/httprunner/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.3"
+__version__ = "2.4.4"
 __description__ = "One-stop solution for HTTP(S) testing."
 
 __all__ = ["__version__", "__description__"]

--- a/httprunner/client.py
+++ b/httprunner/client.py
@@ -111,18 +111,18 @@ class HttpSession(requests.Session):
 
         if "image" in content_type:
             # response is image type, record bytes content only
-            req_resp_dict["response"]["content"] = resp_obj.content
+            req_resp_dict["response"]["body"] = resp_obj.content
         else:
             try:
                 # try to record json data
                 if isinstance(resp_obj, response.ResponseObject):
-                    req_resp_dict["response"]["json"] = resp_obj.json
+                    req_resp_dict["response"]["body"] = resp_obj.json
                 else:
-                    req_resp_dict["response"]["json"] = resp_obj.json()
+                    req_resp_dict["response"]["body"] = resp_obj.json()
             except ValueError:
                 # only record at most 512 text charactors
                 resp_text = resp_obj.text
-                req_resp_dict["response"]["text"] = omit_long_data(resp_text)
+                req_resp_dict["response"]["body"] = omit_long_data(resp_text)
 
         # log response details in debug mode
         log_print(req_resp_dict, "response")

--- a/httprunner/report.py
+++ b/httprunner/report.py
@@ -11,7 +11,7 @@ from jinja2 import Template, escape
 from requests.cookies import RequestsCookieJar
 
 from httprunner import __version__, logger
-from httprunner.compat import basestring, bytes, json, numeric_types
+from httprunner.compat import basestring, bytes, json, numeric_types, JSONDecodeError
 
 
 def get_platform():
@@ -156,7 +156,7 @@ def __stringify_request(request_data):
         if key == "body":
             try:
                 value = json.loads(value)
-            except json.decoder.JSONDecodeError:
+            except JSONDecodeError:
                 pass
 
         if isinstance(value, (list, dict)):

--- a/httprunner/report.py
+++ b/httprunner/report.py
@@ -153,12 +153,6 @@ def __stringify_request(request_data):
     """
     for key, value in request_data.items():
 
-        if key == "body":
-            try:
-                value = json.loads(value)
-            except JSONDecodeError:
-                pass
-
         if isinstance(value, (list, dict)):
             value = dumps_json(value)
 
@@ -168,6 +162,13 @@ def __stringify_request(request_data):
                 value = escape(value.decode(encoding))
             except UnicodeDecodeError:
                 pass
+
+            if key == "body":
+                try:
+                    # request body is in json format
+                    value = json.loads(value)
+                except JSONDecodeError:
+                    pass
 
         elif not isinstance(value, (basestring, numeric_types, Iterable)):
             # class instance, e.g. MultipartEncoder()

--- a/httprunner/report.py
+++ b/httprunner/report.py
@@ -153,6 +153,12 @@ def __stringify_request(request_data):
     """
     for key, value in request_data.items():
 
+        if key == "body":
+            try:
+                value = json.loads(value)
+            except json.decoder.JSONDecodeError:
+                pass
+
         if isinstance(value, (list, dict)):
             value = dumps_json(value)
 

--- a/httprunner/report.py
+++ b/httprunner/report.py
@@ -217,7 +217,7 @@ def __stringify_response(response_data):
                 if not encoding or encoding == "None":
                     encoding = "utf-8"
 
-                if key == "content" and "image" in response_data["content_type"]:
+                if key == "body" and "image" in response_data["content_type"]:
                     # display image
                     value = "data:{};base64,{}".format(
                         response_data["content_type"],

--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -175,7 +175,7 @@ class ResponseObject(object):
                 raise exceptions.ExtractFailure(err_msg)
 
         # response body
-        elif top_query in ["content", "text", "json"]:
+        elif top_query in ["body", "content", "text", "json"]:
             try:
                 body = self.json
             except exceptions.JSONDecodeError:

--- a/httprunner/static/report_template.html
+++ b/httprunner/static/report_template.html
@@ -250,14 +250,14 @@
                       <tr>
                         <th>{{key}}</th>
                         <td>
-                          {% if key == "content" %}
+                          {% if key  == "headers" %}
+                            <pre>{{ value | e }}</pre>
+                          {% elif key == "body" %}
                             {% if "image" in req_resp.response.content_type %}
                               <img src="{{ req_resp.response.content }}" />
                             {% else %}
-                              {{ value }}
-                            {% endif %}
-                          {% elif key in ["headers", "text", "json"] %}
                               <pre>{{ value | e }}</pre>
+                            {% endif %}
                           {% else %}
                             {{ value }}
                           {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "httprunner"
-version = "2.4.3"
+version = "2.4.4"
 description = "One-stop solution for HTTP(S) testing."
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -268,7 +268,7 @@ class TestHttpRunner(ApiServerUnittest):
         self.assertTrue(summary["success"])
         self.assertEqual(summary["stat"]["testcases"]["total"], 1)
         self.assertEqual(summary["stat"]["teststeps"]["total"], 1)
-        resp_json = json.loads(summary["details"][0]["records"][0]["meta_datas"]["data"][0]["response"]["json"])
+        resp_json = json.loads(summary["details"][0]["records"][0]["meta_datas"]["data"][0]["response"]["body"])
         self.assertEqual(
             resp_json["data"],
             "abc"


### PR DESCRIPTION

**Added**

- feat: add keyword `body` to reference response body

**Changed**

- refactor: dumps request/response headers, display indented json in html report
- refactor: dumps request/response body if it is in json format, display indented json in html report
- change: unify response field(content/json/text) to `body` in html report
