### PR TITLE
fix: 批量执行多个测试用例，当执行时间小于1秒报告会被覆盖

### DIFF
--- a/httprunner/report/html/gen_report.py
+++ b/httprunner/report/html/gen_report.py
@@ -41,7 +41,7 @@ def gen_html_report(summary, report_template=None, report_dir=None, report_file=
         report_file_name = os.path.basename(report_file)
     else:
         report_dir = report_dir or os.path.join(os.getcwd(), "reports")
-        report_file_name = "{}.html".format(start_at_timestamp)
+        report_file_name = "{}.html".format(int(start_at_timestamp * 1000)
 
     if not os.path.isdir(report_dir):
         os.makedirs(report_dir)


### PR DESCRIPTION
fix: Batch execution of multiple test cases, when the execution time is less than 1 second, the report will be overwritten