### PR TITLE
2.5.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix #826: Windows does not support file name include ":"
 - fix #819: maximum recursion error in locusts
 - fix #818: request missed url in setup_hooks
+- fix #808: project_working_directory is not initialized when running passed in data structure
 
 ## 2.5.1 (2020-01-02)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - fix #826: Windows does not support file name include ":"
 - fix #819: maximum recursion error in locusts
+- fix #818: request missed url in setup_hooks
 
 ## 2.5.1 (2020-01-02)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixed**
 
 - fix #826: Windows does not support file name include ":"
+- fix #819: maximum recursion error in locusts
 
 ## 2.5.1 (2020-01-02)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.5.2 (2020-01-02)
+
+**Fixed**
+
+- fix #826: Windows does not support file name include ":"
+
 ## 2.5.1 (2020-01-02)
 
 **Fixed**

--- a/httprunner/__init__.py
+++ b/httprunner/__init__.py
@@ -2,15 +2,3 @@ __version__ = "2.5.2"
 __description__ = "One-stop solution for HTTP(S) testing."
 
 __all__ = ["__version__", "__description__"]
-
-import uuid
-
-import sentry_sdk
-
-sentry_sdk.init(
-    dsn="https://cc6dd86fbe9f4e7fbd95248cfcff114d@sentry.io/1862849",
-    release="httprunner@{}".format(__version__)
-)
-
-with sentry_sdk.configure_scope() as scope:
-    scope.set_user({"id": uuid.getnode()})

--- a/httprunner/__init__.py
+++ b/httprunner/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 __description__ = "One-stop solution for HTTP(S) testing."
 
 __all__ = ["__version__", "__description__"]

--- a/httprunner/api.py
+++ b/httprunner/api.py
@@ -292,6 +292,8 @@ class HttpRunner(object):
         if loader.is_test_path(path_or_tests):
             return self.run_path(path_or_tests, dot_env_path, mapping)
         elif loader.is_test_content(path_or_tests):
+            project_working_directory = path_or_tests.get("project_mapping", {}).get("PWD", os.getcwd())
+            loader.init_pwd(project_working_directory)
             return self.run_tests(path_or_tests)
         else:
             raise exceptions.ParamsError("Invalid testcase path or testcases: {}".format(path_or_tests))

--- a/httprunner/cli.py
+++ b/httprunner/cli.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import sys
 
-from sentry_sdk import capture_exception
+import sentry_sdk
 
 from httprunner import __description__, __version__, exceptions
 from httprunner.api import HttpRunner
@@ -11,7 +11,9 @@ from httprunner.loader import load_cases
 from httprunner.logger import color_print, log_error
 from httprunner.report import gen_html_report
 from httprunner.utils import (create_scaffold, get_python2_retire_msg,
-                              prettify_json_file)
+                              prettify_json_file, init_sentry_sdk)
+
+init_sentry_sdk()
 
 
 def main():
@@ -115,7 +117,7 @@ def main():
     except Exception as ex:
         color_print("!!!!!!!!!! exception stage: {} !!!!!!!!!!".format(runner.exception_stage), "YELLOW")
         color_print(str(ex), "RED")
-        capture_exception(ex)
+        sentry_sdk.capture_exception(ex)
         err_code = 1
 
     sys.exit(err_code)

--- a/httprunner/ext/locusts/cli.py
+++ b/httprunner/ext/locusts/cli.py
@@ -19,6 +19,9 @@ import os
 import sys
 
 from httprunner import logger
+from httprunner.utils import init_sentry_sdk
+
+init_sentry_sdk()
 
 
 def parse_locustfile(file_path):

--- a/httprunner/loader/__init__.py
+++ b/httprunner/loader/__init__.py
@@ -9,7 +9,8 @@ HttpRunner loader
 """
 
 from httprunner.loader.check import is_test_path, is_test_content, JsonSchemaChecker
-from httprunner.loader.locate import get_project_working_directory as get_pwd
+from httprunner.loader.locate import get_project_working_directory as get_pwd, \
+    init_project_working_directory as init_pwd
 from httprunner.loader.load import load_csv_file, load_builtin_functions
 from httprunner.loader.buildup import load_cases, load_project_data
 
@@ -18,6 +19,7 @@ __all__ = [
     "is_test_content",
     "JsonSchemaChecker",
     "get_pwd",
+    "init_pwd",
     "load_csv_file",
     "load_builtin_functions",
     "load_project_data",

--- a/httprunner/loader/locate.py
+++ b/httprunner/loader/locate.py
@@ -62,7 +62,11 @@ def locate_debugtalk_py(start_path):
 
 def init_project_working_directory(test_path):
     """ this should be called at startup
-        init_project_working_directory <- load_project_data <- load_cases <- run
+
+        run test file:
+            run_path -> load_cases -> load_project_data -> init_project_working_directory
+        or run passed in data structure:
+            run -> init_project_working_directory
 
     Args:
         test_path: specified testfile path

--- a/httprunner/report/html/gen_report.py
+++ b/httprunner/report/html/gen_report.py
@@ -42,7 +42,8 @@ def gen_html_report(summary, report_template=None, report_dir=None, report_file=
         report_file_name = os.path.basename(report_file)
     else:
         report_dir = report_dir or os.path.join(os.getcwd(), "reports")
-        report_file_name = "{}.html".format(utc_time_iso_8601_str)
+        # fix #826: Windows does not support file name include ":"
+        report_file_name = "{}.html".format(utc_time_iso_8601_str.replace(":", "").replace("-", ""))
 
     if not os.path.isdir(report_dir):
         os.makedirs(report_dir)

--- a/httprunner/report/report.py
+++ b/httprunner/report/report.py
@@ -1,0 +1,51 @@
+import json
+import platform
+import time
+import uuid
+
+import requests
+
+from httprunner import __version__
+
+
+def prepare_event_kwargs(event_name, params):
+    """ prepare report event kwargs"""
+
+    kwargs = {
+        "headers": {
+            'content-type': 'application/json'
+        },
+        "json": {
+            "user": {
+                "user_unique_id": str(uuid.getnode())
+            },
+            "header": {
+                "app_id": 173519,
+                "os_name": platform.system(),
+                "os_version": platform.release(),
+                "app_version": __version__  # HttpRunner version
+            },
+            "events": [
+                {
+                    "event": event_name,
+                    "params": json.dumps(params),
+                    "time": int(time.time())
+                }
+            ],
+            "verbose": 1
+        }
+    }
+    return kwargs
+
+
+def report_event(event_name, success=True):
+    params = {
+        "success": 1 if success else 0
+    }
+    kwargs = prepare_event_kwargs(event_name, params)
+    resp = requests.post("http://mcs.snssdk.com/v1/json", **kwargs)
+    print("resp---", resp.json())
+
+
+if __name__ == '__main__':
+    report_event("loader")

--- a/httprunner/runner.py
+++ b/httprunner/runner.py
@@ -213,15 +213,15 @@ class Runner(object):
         parsed_test_request = self.session_context.eval_content(raw_request)
         self.session_context.update_test_variables("request", parsed_test_request)
 
-        # prepend url with base_url unless it's already an absolute URL
-        url = parsed_test_request.pop('url')
-        base_url = self.session_context.eval_content(test_dict.get("base_url", ""))
-        parsed_url = utils.build_url(base_url, url)
-
         # setup hooks
         setup_hooks = test_dict.get("setup_hooks", [])
         if setup_hooks:
             self.do_hook_actions(setup_hooks, HookTypeEnum.SETUP)
+
+        # prepend url with base_url unless it's already an absolute URL
+        url = parsed_test_request.pop('url')
+        base_url = self.session_context.eval_content(test_dict.get("base_url", ""))
+        parsed_url = utils.build_url(base_url, url)
 
         try:
             method = parsed_test_request.pop('method')

--- a/httprunner/utils.py
+++ b/httprunner/utils.py
@@ -7,13 +7,26 @@ import itertools
 import json
 import os.path
 import re
+import uuid
 from datetime import datetime
 
-from httprunner import exceptions, logger
+import sentry_sdk
+
+from httprunner import exceptions, logger, __version__
 from httprunner.compat import basestring, bytes, is_py2
 from httprunner.exceptions import ParamsError
 
 absolute_http_url_regexp = re.compile(r"^https?://", re.I)
+
+
+def init_sentry_sdk():
+    sentry_sdk.init(
+        dsn="https://cc6dd86fbe9f4e7fbd95248cfcff114d@sentry.io/1862849",
+        release="httprunner@{}".format(__version__)
+    )
+
+    with sentry_sdk.configure_scope() as scope:
+        scope.set_user({"id": uuid.getnode()})
 
 
 def set_os_environ(variables_mapping):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "httprunner"
-version = "2.5.1"
+version = "2.5.2"
 description = "One-stop solution for HTTP(S) testing."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION

**Fixed**

- fix #826: Windows does not support file name include ":"
- fix #819: maximum recursion error in locusts
- fix #818: request missed url in setup_hooks
- fix #808: project_working_directory is not initialized when running passed in data structure
