### PR TITLE
fix -  get response data with jmespath when variable in validate field

### DIFF
--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -189,12 +189,12 @@ class ResponseObject(object):
             check_item = u_validator["check"]
             if "$" in check_item:
                 # check_item is variable or function
-                check_value = parse_data(
+                check_item = parse_data(
                     check_item, variables_mapping, functions_mapping
                 )
-                check_value = parse_string_value(check_value)
-            else:
-                check_value = jmespath.search(check_item, self.resp_obj_meta)
+                check_item = parse_string_value(check_item)
+
+            check_value = jmespath.search(check_item, self.resp_obj_meta)
 
             # comparator
             assert_method = u_validator["assert"]


### PR DESCRIPTION
```yml
- type_match: [body.data."$ids".id, int]
```
为了支持这种验证路径中有variable的情况
修改前会返回
```json
check_item: body.data."$ids".id
check_value: body.data."2565".id(str)
assert_method: type_match
expect_value: int(str)
```