### PR TITLE
3.1.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.1.3 (2020-06-30)
+
+**Fixed**
+
+- fix: validate with variable or function whose evaluation result is "" or not text
+
 ## 3.1.2 (2020-06-29)
 
 **Fixed**

--- a/httprunner/__init__.py
+++ b/httprunner/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 __description__ = "One-stop solution for HTTP(S) testing."
 
 # import firstly for monkey patch if needed

--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -197,7 +197,11 @@ class ResponseObject(object):
                 )
                 check_item = parse_string_value(check_item)
 
-            check_value = jmespath.search(check_item, self.resp_obj_meta)
+            if check_item and isinstance(check_item, Text):
+                check_value = jmespath.search(check_item, self.resp_obj_meta)
+            else:
+                # variable or function evaluation result is "" or not text
+                check_value = check_item
 
             # comparator
             assert_method = u_validator["assert"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "httprunner"
-version = "3.1.2"
+version = "3.1.3"
 description = "One-stop solution for HTTP(S) testing."
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/response_test.py
+++ b/tests/response_test.py
@@ -28,12 +28,28 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(extract_mapping["var_2"], "Olympia")
 
     def test_validate(self):
-        variables_mapping = {"index": 1}
         self.resp_obj.validate(
             [
                 {"eq": ["body.json.locations[0].name", "Seattle"]},
                 {"eq": ["body.json.locations[0]", {"name": "Seattle", "state": "WA"}]},
+            ],
+        )
+
+    def test_validate_variables(self):
+        variables_mapping = {"index": 1, "var_empty": ""}
+        self.resp_obj.validate(
+            [
                 {"eq": ["body.json.locations[$index].name", "New York"]},
+                {"eq": ["$var_empty", ""]},
             ],
             variables_mapping=variables_mapping,
+        )
+
+    def test_validate_functions(self):
+        variables_mapping = {"index": 1}
+        functions_mapping = {"get_num": lambda x: x}
+        self.resp_obj.validate(
+            [{"eq": ["${get_num(0)}", 0]}, {"eq": ["${get_num($index)}", 1]},],
+            variables_mapping=variables_mapping,
+            functions_mapping=functions_mapping,
         )


### PR DESCRIPTION

## 3.1.3 (2020-06-30)

**Fixed**

- fix: validate with variable or function whose evaluation result is "" or not text
