### PR TITLE
如果check_item不是response的对象则用他自己所引用的变量的值，比如可以对自定义函数的返回做校验（场景有正则表达式处理之后校验，或者数据库字段校验，这些都不是response）

### DIFF
--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -211,6 +211,9 @@ class ResponseObject(object):
 
             if check_item and isinstance(check_item, Text):
                 check_value = self._search_jmespath(check_item)
+                #fixed: if _search_jmespath get NoneType use variables check_item
+                if not check_value:
+                    check_value = check_item
             else:
                 # variable or function evaluation result is "" or not text
                 check_value = check_item


### PR DESCRIPTION
if _search_jmespath get NoneType use variables check_item
because sometimes check_item is not the response obj
for example： the function return
        Step(
            RunRequest("visit TesterHome 2")
            .with_variables(
                **{
                    "reg": "<title>(.+?)</title>"
                }
            )
            .get("https://testerhome.com/")
            .teardown_hook("${get_re_value($reg,$response)}","re_value")
            .validate()
            .assert_equal("status_code", 200).assert_equal("$re_value","TesterHome")
        )