### PR TITLE
解决response的dict中如果包含有汉字，显示转义错误的问题

### DIFF
--- a/httprunner/client.py
+++ b/httprunner/client.py
@@ -34,7 +34,7 @@ def get_req_resp_record(resp_obj: Response) -> ReqRespData:
         msg = f"\n================== {r_type} details ==================\n"
         for key, value in req_or_resp.dict().items():
             if isinstance(value, dict):
-                value = json.dumps(value, indent=4)
+                value = json.dumps(value, indent=4, ensure_ascii=False)
 
             msg += "{:<8} : {}\n".format(key, value)
         logger.debug(msg)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21081337/121456406-9b445e00-c9d8-11eb-8ede-030bc0be57b2.png)
问题描述： response中包含 中文，显示乱码。
版本：3.1.4