### PR TITLE
Fixed: 解析 .env 文件忽略注释和空行 && HTTPS 请求获取客户端和服务端 IP 和端口号失败

### DIFF
--- a/httprunner/client.py
+++ b/httprunner/client.py
@@ -181,19 +181,19 @@ class HttpSession(requests.Session):
 
         try:
             client_ip, client_port = response.raw.connection.sock.getsockname()
-            self.data.address.client_ip = client_ip
-            self.data.address.client_port = client_port
-            logger.debug(f"client IP: {client_ip}, Port: {client_port}")
-        except AttributeError as ex:
-            logger.warning(f"failed to get client address info: {ex}")
+        except AttributeError:
+            client_ip, client_port = response.raw.connection.sock.socket.getsockname()
+        self.data.address.client_ip = client_ip
+        self.data.address.client_port = client_port
+        logger.debug(f"client IP: {client_ip}, Port: {client_port}")
 
         try:
             server_ip, server_port = response.raw.connection.sock.getpeername()
-            self.data.address.server_ip = server_ip
-            self.data.address.server_port = server_port
-            logger.debug(f"server IP: {server_ip}, Port: {server_port}")
-        except AttributeError as ex:
-            logger.warning(f"failed to get server address info: {ex}")
+        except AttributeError:
+            server_ip, server_port = response.raw.connection.sock.socket.getpeername()
+        self.data.address.server_ip = server_ip
+        self.data.address.server_port = server_port
+        logger.debug(f"server IP: {server_ip}, Port: {server_port}")
 
         # get length of the response content
         content_size = int(dict(response.headers).get("content-length") or 0)

--- a/httprunner/loader.py
+++ b/httprunner/loader.py
@@ -130,6 +130,9 @@ def load_dot_env_file(dot_env_path: Text) -> Dict:
     with open(dot_env_path, mode="rb") as fp:
         for line in fp:
             # maxsplit=1
+            line = line.strip()
+            if not len(line) or line.startswith(b"#"):
+                continue
             if b"=" in line:
                 variable, value = line.split(b"=", 1)
             elif b":" in line:


### PR DESCRIPTION
修改了两个问题：
1. 解析 .env 文件忽略注释和空行 -- [#1117](https://github.com/httprunner/httprunner/issues/1117)
2. 发起请求会解析客户端和服务端的IP地址和端口号并输出日志，当请求协议为 HTTPS 时，解析失败，抛出异常。

以 `examples/httpbin/basic_test.py` 为例，执行后日志如下：
```
2022-01-18 17:49:05.386 | WARNING  | httprunner.client:request:188 - failed to get client address info: 'WrappedSocket' object has no attribute 'getsockname'
2022-01-18 17:49:05.387 | WARNING  | httprunner.client:request:196 - failed to get server address info: 'WrappedSocket' object has no attribute 'getpeername'
```
修改后 HTTPS 也能正常获取。
```
2022-01-18 17:50:55.244 | DEBUG    | httprunner.client:request:188 - client IP: 192.168.xx.xxx, Port: 62608
2022-01-18 17:50:55.244 | DEBUG    | httprunner.client:request:196 - server IP: 54.221.78.73, Port: 443
```