### PR TITLE
fix: modify loop count

### DIFF
--- a/hrp/internal/boomer/boomer.go
+++ b/hrp/internal/boomer/boomer.go
@@ -78,7 +78,8 @@ func (b *Boomer) GetDisableCompression() bool {
 
 // SetLoopCount set loop count for test.
 func (b *Boomer) SetLoopCount(loopCount int64) {
-	b.localRunner.loop = &Loop{loopCount: loopCount}
+	// total loop count for testcase, it will be evenly distributed to each worker
+	b.localRunner.loop = &Loop{loopCount: loopCount * int64(b.localRunner.spawnCount)}
 }
 
 // AddOutput accepts outputs which implements the boomer.Output interface.

--- a/hrp/internal/boomer/runner_test.go
+++ b/hrp/internal/boomer/runner_test.go
@@ -98,7 +98,7 @@ func TestLoopCount(t *testing.T) {
 	taskA := &Task{
 		Weight: 10,
 		Fn: func() {
-			time.Sleep(time.Second)
+			time.Sleep(time.Millisecond)
 		},
 		Name: "TaskA",
 	}
@@ -107,9 +107,7 @@ func TestLoopCount(t *testing.T) {
 	runner.loop = &Loop{loopCount: 4}
 	runner.setTasks(tasks)
 	go runner.start()
-	ticker := time.NewTicker(4 * time.Second)
-	defer ticker.Stop()
-	<-ticker.C
+	<-runner.stopChan
 	if !assert.Equal(t, runner.loop.loopCount, atomic.LoadInt64(&runner.loop.finishedCount)) {
 		t.Fail()
 	}


### PR DESCRIPTION
循环次数的定义修改：总循环次数==>每个worker的循环次数。
修改前：测试用例的循环次数=loop-count
修改后：测试用例的循环次数=loop-count * spawn-count

测试：
boom examples/ref_api_test.json --spawn-count 10 --loop-count 100
结果：
![image](https://user-images.githubusercontent.com/43516634/159952343-1eeb70c2-2b46-42e5-a116-3c35679c9574.png)
