### PR TITLE
fix: failed to assert when int is compared with int64 #1232

### DIFF
--- a/hrp/internal/builtin/utils.go
+++ b/hrp/internal/builtin/utils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -196,6 +197,39 @@ func Interface2Float64(i interface{}) (float64, error) {
 		return value.Float64()
 	}
 	return 0, errors.New("failed to convert interface to float64")
+}
+
+func TypeNormalization(raw interface{}) interface{} {
+	rawValue := reflect.ValueOf(raw)
+	switch rawValue.Kind() {
+	case reflect.Int:
+		return rawValue.Int()
+	case reflect.Int8:
+		return rawValue.Int()
+	case reflect.Int16:
+		return rawValue.Int()
+	case reflect.Int32:
+		return rawValue.Int()
+	case reflect.Float32:
+		return rawValue.Float()
+	case reflect.Uint:
+		return rawValue.Uint()
+	case reflect.Uint8:
+		return rawValue.Uint()
+	case reflect.Uint16:
+		return rawValue.Uint()
+	case reflect.Uint32:
+		return rawValue.Uint()
+	default:
+		return raw
+	}
+}
+
+func InterfaceType(raw interface{}) string {
+	if raw == nil {
+		return ""
+	}
+	return reflect.TypeOf(raw).String()
 }
 
 var ErrUnsupportedFileExt = fmt.Errorf("unsupported file extension")

--- a/hrp/parser.go
+++ b/hrp/parser.go
@@ -117,7 +117,7 @@ func (p *Parser) Parse(raw interface{}, variablesMapping map[string]interface{})
 		return parsedMap, nil
 	default:
 		// other types, e.g. nil, int, float, bool
-		return raw, nil
+		return builtin.TypeNormalization(raw), nil
 	}
 }
 

--- a/hrp/parser_test.go
+++ b/hrp/parser_test.go
@@ -632,7 +632,7 @@ func TestParseVariables(t *testing.T) {
 	}{
 		{
 			map[string]interface{}{"varA": "$varB", "varB": "$varC", "varC": "123", "a": 1, "b": 2},
-			map[string]interface{}{"varA": "123", "varB": "123", "varC": "123", "a": 1, "b": 2},
+			map[string]interface{}{"varA": "123", "varB": "123", "varC": "123", "a": int64(1), "b": int64(2)},
 		},
 		{
 			map[string]interface{}{"n": 34.5, "a": 12.3, "b": "$n", "varFoo2": "${max($a, $b)}"},

--- a/hrp/response.go
+++ b/hrp/response.go
@@ -170,7 +170,9 @@ func (v *responseObject) Validate(iValidators []interface{}, variablesMapping ma
 			Str("checkExpr", validator.Check).
 			Str("assertMethod", assertMethod).
 			Interface("expectValue", expectValue).
+			Str("expectValueType", builtin.InterfaceType(expectValue)).
 			Interface("checkValue", checkValue).
+			Str("checkValueType", builtin.InterfaceType(checkValue)).
 			Bool("result", result).
 			Msgf("validate %s", checkItem)
 		if !result {
@@ -179,7 +181,9 @@ func (v *responseObject) Validate(iValidators []interface{}, variablesMapping ma
 				Str("checkExpr", validator.Check).
 				Str("assertMethod", assertMethod).
 				Interface("checkValue", checkValue).
+				Str("checkValueType", builtin.InterfaceType(checkValue)).
 				Interface("expectValue", expectValue).
+				Str("expectValueType", builtin.InterfaceType(expectValue)).
 				Msg("assert failed")
 			return errors.New("step validation failed")
 		}


### PR DESCRIPTION
使用GreaterOrEqual做断言时，int与int64类型元素比较会视为不同类型而直接判断为失败
![image](https://user-images.githubusercontent.com/43516634/162695779-55334504-abce-4516-94e0-f808c0e5f613.png)
修改：
1. 新增类型标准化函数，在使用parseString函数时标准化int、float等类型，如统一int、int8、int32、int64类型为int64
2. 日志打印新增打印断言类型

![image](https://user-images.githubusercontent.com/43516634/162700507-34561229-238c-40e1-a1ec-e0cfe2d55b39.png)
