### PR TITLE
fix: deal with extract expr including hyphen

### DIFF
--- a/hrp/step_api.go
+++ b/hrp/step_api.go
@@ -48,6 +48,7 @@ func (path *APIPath) ToAPI() (*API, error) {
 		return nil, err
 	}
 	err = convertCompatValidator(api.Validators)
+	convertExtract(api.Extract)
 	return api, err
 }
 

--- a/hrp/testcase.go
+++ b/hrp/testcase.go
@@ -170,6 +170,9 @@ func (tc *TCase) makeCompat() error {
 		if err != nil {
 			return err
 		}
+
+		// 3. deal with extract expr including hyphen
+		convertExtract(step.Extract)
 	}
 	return nil
 }
@@ -210,6 +213,13 @@ func convertCompatValidator(Validators []interface{}) (err error) {
 		}
 	}
 	return nil
+}
+
+// convertExtract deals with extract expr including hyphen
+func convertExtract(extract map[string]string) {
+	for key, value := range extract {
+		extract[key] = convertCheckExpr(value)
+	}
 }
 
 // convertCheckExpr deals with check expression including hyphen


### PR DESCRIPTION
修复在关联参数中使用jmes_path提取参数时，表达式存在连字符而提取失败问题
如：
```
"extract": {
	"content_type": "headers.Content-Type"
},
```