### PR TITLE
fix: output html report path optimization and failed to extract variables to session while load testing

### DIFF
--- a/.github/workflows/hrp-scaffold.yml
+++ b/.github/workflows/hrp-scaffold.yml
@@ -31,9 +31,11 @@ jobs:
         run: ./output/hrp startproject demo
       - name: Run generated demo tests
         run: ./output/hrp run demo/testcases/
-      - name: Run demo in examples
+      - name: Run API test demo in examples
+        run: ./output/hrp run examples/demo-with-py-plugin/testcases/demo_with_funplugin.json
+      - name: Run load test demo in examples
         run: |
-          ./output/hrp run examples/demo-with-py-plugin/testcases/demo_with_funplugin.json
+          ./output/hrp boom examples/demo-with-py-plugin/testcases/demo_with_funplugin.json --spawn-count 10 --spawn-rate 10 --loop-count 10
 
   scaffold-with-go-plugin:
     strategy:
@@ -56,10 +58,14 @@ jobs:
         run: ./output/hrp startproject demo --go
       - name: Run generated demo tests
         run: ./output/hrp run demo/testcases/
-      - name: Run demo in examples
+      - name: Run API test demo in examples
         run: |
           go build -o examples/demo-with-go-plugin/debugtalk.bin examples/demo-with-go-plugin/plugin/debugtalk.go
           ./output/hrp run examples/demo-with-go-plugin/testcases/demo_with_funplugin.json
+      - name: Run load test demo in examples
+        run: |
+          go build -o examples/demo-with-go-plugin/debugtalk.bin examples/demo-with-go-plugin/plugin/debugtalk.go
+          ./output/hrp boom examples/demo-with-go-plugin/testcases/demo_with_funplugin.json --spawn-count 10 --spawn-rate 10 --loop-count 10
 
   scaffold-without-custom-plugin:
     strategy:
@@ -82,6 +88,8 @@ jobs:
         run: ./output/hrp startproject demo --ignore-plugin
       - name: Run generated demo tests
         run: ./output/hrp run demo/testcases/demo_without_funplugin.json
-      - name: Run demo in examples
+      - name: Run API test demo in examples
+        run: ./output/hrp run examples/demo-without-plugin/testcases/demo_without_funplugin.json
+      - name: Run load test demo in examples
         run: |
-          ./output/hrp run examples/demo-without-plugin/testcases/demo_without_funplugin.json
+          ./output/hrp boom examples/demo-without-plugin/testcases/demo_without_funplugin.json --spawn-count 10 --spawn-rate 10 --loop-count 10

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -1,4 +1,4 @@
-name: run smoke tests for httprunner
+name: run smoke tests
 
 on:
   push:
@@ -10,9 +10,9 @@ env:
   DISABLE_GA: "true"
 
 jobs:
-  smoke-test:
+  smoke-test-httprunner:
 
-    name: smoketest - ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: smoketest - httprunner - ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -47,3 +47,29 @@ jobs:
     - name: Run smoketest - httpbin
       run: |
         poetry run hrun examples/httpbin/
+
+  smoke-test-hrp:
+    name: smoketest - hrp - ${{ matrix.go-version }} on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - 1.17.x
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build hrp binary
+        run: make build
+      - name: Run smoketest - postman echo
+        run: ./output/hrp boom examples/hrp/postman-echo.json --spawn-count 10 --spawn-rate 10 --loop-count 10
+      - name: Run smoketest - data driven with parameterize mechanism
+        run: ./output/hrp boom examples/hrp/parameters_test.json --spawn-count 10 --spawn-rate 10 --loop-count 10
+      - name: Run smoketest - rendezvous
+        run: |
+          ./output/hrp boom examples/hrp/rendezvous_test.json --spawn-count 10 --spawn-rate 10 --loop-count 10

--- a/hrp/boomer.go
+++ b/hrp/boomer.go
@@ -125,7 +125,7 @@ func (b *HRPBoomer) convertBoomerTask(testcase *TestCase, rendezvousList []*Rend
 					transactionSuccess = false
 
 					if b.hrpRunner.failfast {
-						log.Error().Msg("abort running due to failfast setting")
+						log.Error().Err(err).Msg("abort running due to failfast setting")
 						break
 					}
 					log.Warn().Err(err).Msg("run step failed, continue next step")
@@ -148,6 +148,10 @@ func (b *HRPBoomer) convertBoomerTask(testcase *TestCase, rendezvousList []*Rend
 				} else {
 					// request or testcase step
 					b.RecordSuccess(string(step.Type()), step.Name(), stepResult.Elapsed, stepResult.ContentSize)
+					// update extracted variables
+					for k, v := range stepResult.ExportVars {
+						sessionRunner.sessionVariables[k] = v
+					}
 				}
 			}
 			endTime := time.Now()

--- a/hrp/runner.go
+++ b/hrp/runner.go
@@ -182,6 +182,14 @@ func (r *HRPRunner) Run(testcases ...ITestCase) error {
 	}
 	s.Time.Duration = time.Since(s.Time.StartAt).Seconds()
 
+	// update the report output path
+	pluginPath, err := locatePlugin(testcases[0].GetPath())
+	if err == nil {
+		outputPath, _ := filepath.Split(pluginPath)
+		summaryPath = filepath.Join(outputPath, summaryPath)
+		reportPath = filepath.Join(outputPath, reportPath)
+	}
+
 	// save summary
 	if r.saveTests {
 		dir, _ := filepath.Split(summaryPath)

--- a/hrp/summary.go
+++ b/hrp/summary.go
@@ -61,7 +61,8 @@ func (s *Summary) genHTMLReport() error {
 	if err != nil {
 		return err
 	}
-	file, err := os.OpenFile(fmt.Sprintf(reportPath, s.Time.StartAt.Unix()), os.O_WRONLY|os.O_CREATE, 0666)
+	reportPath := fmt.Sprintf(reportPath, s.Time.StartAt.Unix())
+	file, err := os.OpenFile(reportPath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		log.Error().Err(err).Msg("open file failed")
 		return err
@@ -75,15 +76,20 @@ func (s *Summary) genHTMLReport() error {
 		return err
 	}
 	err = writer.Flush()
+	if err == nil {
+		log.Info().Str("path", reportPath).Msg("generate HTML report")
+	} else {
+		log.Error().Str("path", reportPath).Msg("generate HTML report failed")
+	}
 	return err
 }
 
 //go:embed internal/scaffold/templates/report/template.html
 var reportTemplate string
 
-const (
-	reportPath  string = "reports/report-%v.html"
-	summaryPath string = "reports/summary-%v.json"
+var (
+	reportPath  = "reports/report-%v.html"
+	summaryPath = "reports/summary-%v.json"
 )
 
 type Stat struct {


### PR DESCRIPTION
1. 修改reports报告导出路径逻辑，默认导出至plugin文件所在路径，如果定位失败，则当前运行目录作为兜底路径
2. 增加报告输出路径打印
3. 修复执行压力测试时，extract导出变量未生效而导致关联参数引用失败问题