### PR TITLE
fix: disable keep alive and improve RPS accuracy

### DIFF
--- a/hrp/boomer.go
+++ b/hrp/boomer.go
@@ -19,9 +19,6 @@ func NewBoomer(spawnCount int, spawnRate float64) *HRPBoomer {
 	}
 
 	b.hrpRunner = NewRunner(nil)
-	// set client transport for high concurrency load testing
-	b.hrpRunner.SetClientTransport(b.GetSpawnCount(), b.GetDisableKeepAlive(), b.GetDisableCompression())
-
 	return b
 }
 
@@ -30,6 +27,11 @@ type HRPBoomer struct {
 	hrpRunner    *HRPRunner
 	plugins      []funplugin.IPlugin // each task has its own plugin process
 	pluginsMutex *sync.RWMutex       // avoid data race
+}
+
+func (b *HRPBoomer) SetClientTransport() {
+	// set client transport for high concurrency load testing
+	b.hrpRunner.SetClientTransport(b.GetSpawnCount(), b.GetDisableKeepAlive(), b.GetDisableCompression())
 }
 
 // Run starts to run load test for one or multiple testcases.

--- a/hrp/boomer.go
+++ b/hrp/boomer.go
@@ -99,6 +99,9 @@ func (b *HRPBoomer) convertBoomerTask(testcase *TestCase, rendezvousList []*Rend
 	parametersIterator := caseRunner.parametersIterator
 	parametersIterator.SetUnlimitedMode()
 
+	// reset start time only once
+	once := sync.Once{}
+
 	return &boomer.Task{
 		Name:   testcase.Config.Name,
 		Weight: testcase.Config.Weight,
@@ -115,6 +118,10 @@ func (b *HRPBoomer) convertBoomerTask(testcase *TestCase, rendezvousList []*Rend
 
 			startTime := time.Now()
 			for _, step := range testcase.TestSteps {
+				// reset start time only once before step
+				once.Do(func() {
+					b.Boomer.ResetStartTime()
+				})
 				stepResult, err := step.Run(sessionRunner)
 				if err != nil {
 					// step failed

--- a/hrp/cmd/boom.go
+++ b/hrp/cmd/boom.go
@@ -41,6 +41,7 @@ var boomCmd = &cobra.Command{
 		}
 		hrpBoomer.SetDisableKeepAlive(disableKeepalive)
 		hrpBoomer.SetDisableCompression(disableCompression)
+		hrpBoomer.SetClientTransport()
 		hrpBoomer.EnableCPUProfile(cpuProfile, cpuProfileDuration)
 		hrpBoomer.EnableMemoryProfile(memoryProfile, memoryProfileDuration)
 		hrpBoomer.EnableGracefulQuit()

--- a/hrp/internal/boomer/boomer.go
+++ b/hrp/internal/boomer/boomer.go
@@ -170,3 +170,7 @@ func (b *Boomer) GetSpawnDoneChan() chan struct{} {
 func (b *Boomer) GetSpawnCount() int {
 	return b.localRunner.spawnCount
 }
+
+func (b *Boomer) ResetStartTime() {
+	b.localRunner.stats.total.resetStartTime()
+}

--- a/hrp/internal/boomer/output.go
+++ b/hrp/internal/boomer/output.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/rs/zerolog/log"
@@ -264,10 +265,9 @@ func deserializeStatsEntry(stat interface{}) (entryOutput *statsEntryOutput, err
 
 	var duration float64
 	if entry.Name == "Total" {
-		duration = float64(entry.LastRequestTimestamp - entry.StartTime)
-		// fix: avoid divide by zero
-		if duration < 1 {
-			duration = 1
+		duration = float64(entry.LastRequestTimestamp-entry.StartTime) / 1e3
+		if duration == 0 {
+			return nil, errors.New("no step specified")
 		}
 	} else {
 		duration = float64(reportStatsInterval / time.Second)

--- a/hrp/internal/boomer/runner.go
+++ b/hrp/internal/boomer/runner.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/olekukonko/tablewriter"
-
 	"github.com/rs/zerolog/log"
 )
 
@@ -154,7 +153,7 @@ func (r *runner) reportTestResult() {
 	if err != nil {
 		return
 	}
-	duration := time.Duration(entryTotalOutput.LastRequestTimestamp-entryTotalOutput.StartTime) * time.Second
+	duration := time.Duration(entryTotalOutput.LastRequestTimestamp-entryTotalOutput.StartTime) * time.Millisecond
 	currentTime := time.Now()
 	println(fmt.Sprint("=========================================== Statistics Summary =========================================="))
 	println(fmt.Sprintf("Current time: %s, Users: %v, Duration: %v, Accumulated Transactions: %d Passed, %d Failed",


### PR DESCRIPTION
## Main changes
1. 修复 --disable-keepalive 选项关闭 HTTP 长连接时不能生效的问题
2. 响应时间精确到小数点后三位（毫秒），提升较低循环次数下 RPS 计算结果的准确性

## How did I test these changes?
针对同一接口，单个虚拟用户，1秒到达，循环100次。分别使用 HttpRunner 和 JMeter 进行压测：
### 关闭长连接
HttpRunner 结果
![image](https://user-images.githubusercontent.com/41049280/167412785-f63234f5-f00d-42aa-a163-92cec90ef749.png)
JMeter 结果
![image](https://user-images.githubusercontent.com/41049280/167413001-fab49d37-e9b4-4f67-9be6-31d58a6b79f0.png)

### 开启长连接
HttpRunner 结果
![image](https://user-images.githubusercontent.com/41049280/167413420-99c85098-c707-43d9-b9a7-7ca3c47bb613.png)
JMeter 结果
![image](https://user-images.githubusercontent.com/41049280/167413470-4999eb29-e53a-400a-99fd-461f4f412ba7.png)


