### PR TITLE
fix: unsafe to write concurrent map and failed to parse parameters(type:[][]interface{}) in testcase script while data driven for testing

### DIFF
--- a/hrp/boomer.go
+++ b/hrp/boomer.go
@@ -108,7 +108,7 @@ func (b *HRPBoomer) convertBoomerTask(testcase *TestCase, rendezvousList []*Rend
 			sessionRunner := caseRunner.newSession()
 
 			if parametersIterator.HasNext() {
-				sessionRunner.updateConfigVariables(parametersIterator.Next())
+				sessionRunner.updateSessionVariables(parametersIterator.Next())
 			}
 
 			startTime := time.Now()

--- a/hrp/parameters.go
+++ b/hrp/parameters.go
@@ -311,6 +311,10 @@ func convertParameters(key string, parametersRawList interface{}) (parameterSlic
 	for i := 0; i < parametersRawSlice.Len(); i++ {
 		parametersLine := make(map[string]interface{})
 		elem := parametersRawSlice.Index(i)
+		// e.g. Type: interface{} | []interface{}, convert interface{} to []interface{}
+		if elem.Kind() == reflect.Interface {
+			elem = elem.Elem()
+		}
 		switch elem.Kind() {
 		case reflect.Slice:
 			// case 3

--- a/hrp/parameters_test.go
+++ b/hrp/parameters_test.go
@@ -48,6 +48,20 @@ func TestLoadParameters(t *testing.T) {
 			},
 		},
 		{
+			map[string]interface{}{
+				"username-password": []interface{}{
+					[]interface{}{"test1", "111111"},
+					[]interface{}{"test2", "222222"},
+				},
+			},
+			map[string]Parameters{
+				"username-password": {
+					{"username": "test1", "password": "111111"},
+					{"username": "test2", "password": "222222"},
+				},
+			},
+		},
+		{
 			map[string]interface{}{},
 			nil,
 		},

--- a/hrp/session.go
+++ b/hrp/session.go
@@ -52,11 +52,11 @@ func (r *SessionRunner) Start(givenVars map[string]interface{}) error {
 	config := r.testCase.Config
 	log.Info().Str("testcase", config.Name).Msg("run testcase start")
 
-	// update config variables with given variables
-	r.updateConfigVariables(givenVars)
-
 	// reset session runner
 	r.resetSession()
+
+	// update config variables with given variables
+	r.updateSessionVariables(givenVars)
 
 	// run step in sequential order
 	for _, step := range r.testCase.TestSteps {
@@ -122,16 +122,16 @@ func (r *SessionRunner) MergeStepVariables(vars map[string]interface{}) (map[str
 	return parsedVariables, nil
 }
 
-// updateConfigVariables updates config variables with given variables.
+// updateSessionVariables updates session variables with given variables.
 // this is used for data driven
-func (r *SessionRunner) updateConfigVariables(parameters map[string]interface{}) {
+func (r *SessionRunner) updateSessionVariables(parameters map[string]interface{}) {
 	if len(parameters) == 0 {
 		return
 	}
 
-	log.Info().Interface("parameters", parameters).Msg("update config variables")
+	log.Info().Interface("parameters", parameters).Msg("update session variables")
 	for k, v := range parameters {
-		r.parsedConfig.Variables[k] = v
+		r.sessionVariables[k] = v
 	}
 }
 


### PR DESCRIPTION
fix: unsafe to write concurrent map while data driven for testing
问题定位：将参数驱动迭代器中的参数合并到parsedConfig.variables的结果是多goroutine共享的，会存在concurrent map writes问题，因此将参数驱动迭代器中的参数合并到sessionVariables中，效果一致
fix: failed to parse parameters(type:[][]interface{}) in testcase script while data driven for testing
问题定位：
case：
```
"parameters": {
      "username-password": [["user1","11111"], ["user2","22222"]]
},
```
error：
```
 ERR parameters format error lineIndex=0 parameterNames=["username","password"]
2:28PM ERR parse config parameters failed error="parameters format error" parameters={"user_agent":["iOS/10.1","iOS/10.2"],"username-password":[["user1","11111"],["user2","22222"]]} parametersSetting={"limit":6,"strategies":{"user_agent":"sequential","username-password":"random"}}
2:28PM ERR failed to create runner error="parse testcase config failed: parse testcase config parameters failed: parameters format error"

```
