### PR TITLE
fix: add boomer mode(standalone/master/worker)

### DIFF
--- a/hrp/cmd/boom.go
+++ b/hrp/cmd/boom.go
@@ -37,7 +37,7 @@ var boomCmd = &cobra.Command{
 			hrpBoomer.AddOutput(boomer.NewConsoleOutput())
 		}
 		if prometheusPushgatewayURL != "" {
-			hrpBoomer.AddOutput(boomer.NewPrometheusPusherOutput(prometheusPushgatewayURL, "hrp"))
+			hrpBoomer.AddOutput(boomer.NewPrometheusPusherOutput(prometheusPushgatewayURL, "hrp", hrpBoomer.GetMode()))
 		}
 		hrpBoomer.SetDisableKeepAlive(disableKeepalive)
 		hrpBoomer.SetDisableCompression(disableCompression)

--- a/hrp/internal/boomer/boomer.go
+++ b/hrp/internal/boomer/boomer.go
@@ -7,11 +7,26 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+)
+
+// Mode is the running mode of boomer, both standalone and distributed are supported.
+type Mode int
+
+const (
+	// DistributedMasterMode requires being connected by each worker.
+	DistributedMasterMode Mode = iota
+	// DistributedWorkerMode requires connecting to a master.
+	DistributedWorkerMode
+	// StandaloneMode will run without a master.
+	StandaloneMode
 )
 
 // A Boomer is used to run tasks.
 type Boomer struct {
+	mode Mode
+
 	localRunner *localRunner
 
 	cpuProfile         string
@@ -24,9 +39,39 @@ type Boomer struct {
 	disableCompression bool
 }
 
+// SetMode only accepts boomer.DistributedMasterMode、boomer.DistributedWorkerMode and boomer.StandaloneMode.
+func (b *Boomer) SetMode(mode Mode) {
+	switch mode {
+	case DistributedMasterMode:
+		b.mode = DistributedMasterMode
+	case DistributedWorkerMode:
+		b.mode = DistributedWorkerMode
+	case StandaloneMode:
+		b.mode = StandaloneMode
+	default:
+		log.Error().Err(errors.New("Invalid mode, ignored!"))
+	}
+}
+
+// GetMode returns boomer operating mode
+func (b *Boomer) GetMode() string {
+	switch b.mode {
+	case DistributedMasterMode:
+		return "master"
+	case DistributedWorkerMode:
+		return "worker"
+	case StandaloneMode:
+		return "standalone"
+	default:
+		log.Error().Err(errors.New("Invalid mode, ignored!"))
+		return ""
+	}
+}
+
 // NewStandaloneBoomer returns a new Boomer, which can run without master.
 func NewStandaloneBoomer(spawnCount int, spawnRate float64) *Boomer {
 	return &Boomer{
+		mode:        StandaloneMode,
 		localRunner: newLocalRunner(spawnCount, spawnRate),
 	}
 }

--- a/hrp/internal/boomer/output.go
+++ b/hrp/internal/boomer/output.go
@@ -471,10 +471,12 @@ var (
 )
 
 // NewPrometheusPusherOutput returns a PrometheusPusherOutput.
-func NewPrometheusPusherOutput(gatewayURL, jobName string) *PrometheusPusherOutput {
+func NewPrometheusPusherOutput(gatewayURL, jobName string, mode string) *PrometheusPusherOutput {
 	nodeUUID, _ := uuid.NewUUID()
 	return &PrometheusPusherOutput{
-		pusher: push.New(gatewayURL, jobName).Grouping("instance", nodeUUID.String()),
+		pusher: push.New(gatewayURL, jobName).
+			Grouping("instance", nodeUUID.String()).
+			Grouping("mode", mode),
 	}
 }
 


### PR DESCRIPTION
增加boomer运行模式：
1. 分布式/单机模式下指标聚合维度不同，便于prometheus进行指标聚合数据可视化
![image](https://user-images.githubusercontent.com/43516634/167987186-7849b29e-9fa0-4414-bf39-81cb0f8eb740.png)
