### PR TITLE
fix: panic when config didn't exist in testcase file

### DIFF
--- a/hrp/testcase.go
+++ b/hrp/testcase.go
@@ -60,6 +60,9 @@ func (path *TestCasePath) ToTestCase() (*TestCase, error) {
 	if err != nil {
 		return nil, err
 	}
+	if tc.Config == nil {
+		return nil, errors.New("incorrect testcase file format, expected config in file")
+	}
 
 	err = tc.makeCompat()
 	if err != nil {


### PR DESCRIPTION
panic原因：测试用例文件中没有config，反序列化后，tc中的config为nil，由对nil指针赋值产生