### PR TITLE
fix: failed to generate a report in failfast mode #1315

### DIFF
--- a/hrp/runner.go
+++ b/hrp/runner.go
@@ -179,12 +179,13 @@ func (r *HRPRunner) Run(testcases ...ITestCase) error {
 		}()
 
 		for it := sessionRunner.parametersIterator; it.HasNext(); {
-			if err = sessionRunner.Start(it.Next()); err != nil {
-				log.Error().Err(err).Msg("[Run] run testcase failed")
-				return err
-			}
+			err = sessionRunner.Start(it.Next())
 			caseSummary := sessionRunner.GetSummary()
 			s.appendCaseSummary(caseSummary)
+			if err != nil {
+				log.Error().Err(err).Msg("[Run] run testcase failed")
+				break
+			}
 		}
 	}
 	s.Time.Duration = time.Since(s.Time.StartAt).Seconds()


### PR DESCRIPTION
修复: 
1. failfast模式下，测试步执行失败不生产html报告问题
2. failfast模式下，单用例中执行测试步失败后不影响其他测试用例执行
![image](https://user-images.githubusercontent.com/43516634/170470084-5319058f-4261-44e2-b456-53b65f576e88.png)
