### PR TITLE
fix: set ulimit error

### DIFF
--- a/hrp/internal/boomer/ulimit.go
+++ b/hrp/internal/boomer/ulimit.go
@@ -23,6 +23,7 @@ func SetUlimit(limit uint64) {
 	}
 
 	rLimit.Cur = limit
+	rLimit.Max = limit
 	log.Info().Uint64("limit", rLimit.Cur).Msg("set current ulimit")
 	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {


### PR DESCRIPTION
## Main Changes
- 修复 #1312 中用户提到的 linux 下 `hrp boom` 设置文件描述符报错 `ERR set ulimit failed error="invalid argument"` 问题

## Solution
解决方案主要受 [How to set ulimit -n from a golang program?](https://stackoverflow.com/questions/17817204/how-to-set-ulimit-n-from-a-golang-program) 启发，帖子中提到 linux 32 位存在"invalid argument"问题，而 linux 64 位不存在。进而猜测是由于 `SetUlimit` 函数在构建 `syscall.Rlimit` 结构体时只对 Cur 字段赋值，结果导致 Max 字段小于 Cur，引发了"invalid argument"问题。经试验对 Max 字段赋值，并且保证 Max>=Cur 字段后，该问题不再出现，至于"operation not permitted"问题，只需要用户在指令前加上 `sudo` 即可解决