### PR TITLE
fix: failed to build debugtalk.go without go.mod

### DIFF
--- a/examples/demo-empty-project/proj.json
+++ b/examples/demo-empty-project/proj.json
@@ -1,6 +1,5 @@
 {
     "project_name": "demo-empty-project",
-    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-empty-project",
-    "create_time": "2022-05-31T13:12:05.552655+08:00",
+    "create_time": "2022-05-31T15:05:51.196187+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/examples/demo-empty-project/proj.json
+++ b/examples/demo-empty-project/proj.json
@@ -1,6 +1,6 @@
 {
     "project_name": "demo-empty-project",
-    "project_path": "/Users/debugtalk/MyProjects/HttpRunner-dev/httprunner/examples/demo-empty-project",
-    "create_time": "2022-05-29T13:24:31.960615+08:00",
+    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-empty-project",
+    "create_time": "2022-05-31T13:12:05.552655+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/examples/demo-with-go-plugin/proj.json
+++ b/examples/demo-with-go-plugin/proj.json
@@ -1,6 +1,5 @@
 {
     "project_name": "demo-with-go-plugin",
-    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-with-go-plugin",
-    "create_time": "2022-05-31T13:12:04.150418+08:00",
+    "create_time": "2022-05-31T15:05:49.894029+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/examples/demo-with-go-plugin/proj.json
+++ b/examples/demo-with-go-plugin/proj.json
@@ -1,6 +1,6 @@
 {
     "project_name": "demo-with-go-plugin",
-    "project_path": "/Users/debugtalk/MyProjects/HttpRunner-dev/httprunner/examples/demo-with-go-plugin",
-    "create_time": "2022-05-29T13:24:29.431434+08:00",
+    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-with-go-plugin",
+    "create_time": "2022-05-31T13:12:04.150418+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/examples/demo-with-py-plugin/proj.json
+++ b/examples/demo-with-py-plugin/proj.json
@@ -1,6 +1,5 @@
 {
     "project_name": "demo-with-py-plugin",
-    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-with-py-plugin",
-    "create_time": "2022-05-31T13:12:04.292557+08:00",
+    "create_time": "2022-05-31T15:05:50.036068+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/examples/demo-with-py-plugin/proj.json
+++ b/examples/demo-with-py-plugin/proj.json
@@ -1,6 +1,6 @@
 {
     "project_name": "demo-with-py-plugin",
-    "project_path": "/Users/debugtalk/MyProjects/HttpRunner-dev/httprunner/examples/demo-with-py-plugin",
-    "create_time": "2022-05-29T13:24:29.566414+08:00",
+    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-with-py-plugin",
+    "create_time": "2022-05-31T13:12:04.292557+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/examples/demo-without-plugin/proj.json
+++ b/examples/demo-without-plugin/proj.json
@@ -1,6 +1,6 @@
 {
     "project_name": "demo-without-plugin",
-    "project_path": "/Users/debugtalk/MyProjects/HttpRunner-dev/httprunner/examples/demo-without-plugin",
-    "create_time": "2022-05-29T13:24:31.840718+08:00",
+    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-without-plugin",
+    "create_time": "2022-05-31T13:12:05.424068+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/examples/demo-without-plugin/proj.json
+++ b/examples/demo-without-plugin/proj.json
@@ -1,6 +1,5 @@
 {
     "project_name": "demo-without-plugin",
-    "project_path": "/Users/xxxxx/go/src/github.com/httprunner/httprunner/examples/demo-without-plugin",
-    "create_time": "2022-05-31T13:12:05.424068+08:00",
+    "create_time": "2022-05-31T15:05:51.066376+08:00",
     "hrp_version": "v4.1.0"
 }

--- a/hrp/internal/scaffold/main.go
+++ b/hrp/internal/scaffold/main.go
@@ -28,7 +28,6 @@ const (
 
 type ProjectInfo struct {
 	ProjectName string    `json:"project_name,omitempty" yaml:"project_name,omitempty"`
-	ProjectPath string    `json:"project_path,omitempty" yaml:"project_path,omitempty"`
 	CreateTime  time.Time `json:"create_time,omitempty" yaml:"create_time,omitempty"`
 	Version     string    `json:"hrp_version,omitempty" yaml:"hrp_version,omitempty"`
 }
@@ -78,12 +77,6 @@ func CreateScaffold(projectName string, pluginType PluginType, force bool) error
 		os.RemoveAll(projectName)
 	}
 
-	// get project abs path
-	projectPath, err := filepath.Abs(projectName)
-	if err != nil {
-		projectPath = projectName
-	}
-
 	// create project folders
 	if err := builtin.CreateFolder(projectName); err != nil {
 		return err
@@ -106,13 +99,12 @@ func CreateScaffold(projectName string, pluginType PluginType, force bool) error
 
 	projectInfo := &ProjectInfo{
 		ProjectName: filepath.Base(projectName),
-		ProjectPath: projectPath,
 		CreateTime:  time.Now(),
 		Version:     version.VERSION,
 	}
 
 	// dump project information to file
-	err = builtin.Dump2JSON(projectInfo, filepath.Join(projectName, "proj.json"))
+	err := builtin.Dump2JSON(projectInfo, filepath.Join(projectName, "proj.json"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
修改：保留项目plugin目录下的go.mod，仅在第一次初始化go.mod时go get funplugin@latest，减少go mod init、go get 重复下载带来的不必要耗时