### PR TITLE
support skip for pyest

### DIFF
--- a/httprunner/make.py
+++ b/httprunner/make.py
@@ -52,7 +52,7 @@ from httprunner import HttpRunner, Config, Step, RunRequest, RunTestCase
 class {{ class_name }}(HttpRunner):
     {% if parameters and skip %}
     @pytest.mark.parametrize("param", Parameters({{parameters}}))
-    @pytest.mark.skip(reason={{ reason }})
+    @pytest.mark.skip(reason={{ skip }})
     def test_start(self, param):
         super().test_start(param)
 
@@ -62,7 +62,7 @@ class {{ class_name }}(HttpRunner):
         super().test_start(param)
 
     {% elif skip %}
-    @pytest.mark.skip(reason={{ reason }})
+    @pytest.mark.skip(reason={{ skip }})
     def test_start(self):
         super().test_start()
 
@@ -221,10 +221,10 @@ def make_config_chain_style(config: Dict) -> Text:
 def make_config_skip(config: Dict) -> Text:
     if "skip" in config:
         if config["skip"]:
-            config_skip = config["skip"]
+            config_chain_style = config["skip"]
         else:
-            config_skip = '"skip unconditionally"'
-        return config_skip
+            config_chain_style = '"skip unconditionally"'
+        return config_chain_style
 
 
 def make_request_chain_style(request: Dict) -> Text:
@@ -438,11 +438,11 @@ def make_testcase(testcase: Dict, dir_path: Text = None) -> Text:
         "config_chain_style": make_config_chain_style(config),
         "parameters": config.get("parameters"),
         "skip": make_config_skip(config),
-        "reason": make_config_skip(config),
         "teststeps_chain_style": [
             make_teststep_chain_style(step) for step in teststeps
         ],
     }
+    logger.info(make_config_skip(config))
     content = __TEMPLATE__.render(data)
 
     # ensure new file's directory exists

--- a/httprunner/make.py
+++ b/httprunner/make.py
@@ -36,8 +36,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__){% for _ in range(diff_levels) %}.parent{% endfor %}))
 {% endif %}
 
-{% if parameters %}
+{% if parameters or skip %}
 import pytest
+{% endif %}
+
+{% if parameters %}
 from httprunner import Parameters
 {% endif %}
 
@@ -47,11 +50,22 @@ from httprunner import HttpRunner, Config, Step, RunRequest, RunTestCase
 {% endfor %}
 
 class {{ class_name }}(HttpRunner):
+    {% if parameters and skip %}
+    @pytest.mark.parametrize("param", Parameters({{parameters}}))
+    @pytest.mark.skip({{ reason }})
+    def test_start(self, param):
+        super().test_start(param)
 
-    {% if parameters %}
+    {% elif parameters %}
     @pytest.mark.parametrize("param", Parameters({{parameters}}))
     def test_start(self, param):
         super().test_start(param)
+
+    {% elif skip %}
+    @pytest.mark.skip({{ reason }})
+    def test_start(self):
+        super().test_start()
+
     {% endif %}
 
     config = {{ config_chain_style }}
@@ -201,6 +215,15 @@ def make_config_chain_style(config: Dict) -> Text:
     if "weight" in config:
         config_chain_style += f'.locust_weight({config["weight"]})'
 
+    return config_chain_style
+
+
+def make_config_skip(config: Dict) -> Text:
+    if "skip" in config:
+        if config["skip"]:
+            config_chain_style = config["skip"]
+        else:
+            config_chain_style = '"skip unconditionally"'
     return config_chain_style
 
 
@@ -414,10 +437,13 @@ def make_testcase(testcase: Dict, dir_path: Text = None) -> Text:
         "imports_list": imports_list,
         "config_chain_style": make_config_chain_style(config),
         "parameters": config.get("parameters"),
+        "skip": make_config_skip(config),
+        "reason": str(make_config_skip(config)),
         "teststeps_chain_style": [
             make_teststep_chain_style(step) for step in teststeps
         ],
     }
+    logger.info(make_config_skip(config))
     content = __TEMPLATE__.render(data)
 
     # ensure new file's directory exists

--- a/httprunner/make.py
+++ b/httprunner/make.py
@@ -221,10 +221,10 @@ def make_config_chain_style(config: Dict) -> Text:
 def make_config_skip(config: Dict) -> Text:
     if "skip" in config:
         if config["skip"]:
-            config_chain_style = config["skip"]
+            config_skip = config["skip"]
         else:
-            config_chain_style = '"skip unconditionally"'
-    return config_chain_style
+            config_skip = '"skip unconditionally"'
+        return config_skip
 
 
 def make_request_chain_style(request: Dict) -> Text:
@@ -438,12 +438,11 @@ def make_testcase(testcase: Dict, dir_path: Text = None) -> Text:
         "config_chain_style": make_config_chain_style(config),
         "parameters": config.get("parameters"),
         "skip": make_config_skip(config),
-        "reason": str(make_config_skip(config)),
+        "reason": make_config_skip(config),
         "teststeps_chain_style": [
             make_teststep_chain_style(step) for step in teststeps
         ],
     }
-    logger.info(make_config_skip(config))
     content = __TEMPLATE__.render(data)
 
     # ensure new file's directory exists

--- a/httprunner/make.py
+++ b/httprunner/make.py
@@ -52,7 +52,7 @@ from httprunner import HttpRunner, Config, Step, RunRequest, RunTestCase
 class {{ class_name }}(HttpRunner):
     {% if parameters and skip %}
     @pytest.mark.parametrize("param", Parameters({{parameters}}))
-    @pytest.mark.skip({{ reason }})
+    @pytest.mark.skip(reason={{ reason }})
     def test_start(self, param):
         super().test_start(param)
 
@@ -62,7 +62,7 @@ class {{ class_name }}(HttpRunner):
         super().test_start(param)
 
     {% elif skip %}
-    @pytest.mark.skip({{ reason }})
+    @pytest.mark.skip(reason={{ reason }})
     def test_start(self):
         super().test_start()
 


### PR DESCRIPTION
需求背景：项目迭代开发中有些用例无法使用，需要暂时跳过这些不可用的用例
使用示例：

```
config:
    name: testcase description
    variables: {}
    verify: false
    parameters:
        title-user-pwd:
            -   ['ces1', 112, 222]
    skip: '跳过原因，可不写， 默认输出无条件跳过'
```

#1153