### PR TITLE
v4增加pytest skip特性

### DIFF
--- a/httprunner/make.py
+++ b/httprunner/make.py
@@ -42,8 +42,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__){% for _ in range(diff_levels) %}.parent{% endfor %}))
 {% endif %}
 
+{% if parameters or skip %}
+import pytes
+{% endif %}
+
 {% if parameters %}
-import pytest
 from httprunner import Parameters
 {% endif %}
 
@@ -54,10 +57,21 @@ from httprunner import HttpRunner, Config, Step, RunRequest, RunTestCase
 
 class {{ class_name }}(HttpRunner):
 
-    {% if parameters %}
+    {% if parameters and skip %}
+    @pytest.mark.parametrize("param", Parameters({{parameters}}))
+    @pytest.mark.skip(reason={{ skip }})
+    def test_start(self, param):
+        super().test_start(param)
+        
+    {% elif parameters %}
     @pytest.mark.parametrize("param", Parameters({{parameters}}))
     def test_start(self, param):
         super().test_start(param)
+        
+    {% elif skip %}
+    @pytest.mark.skip(reason={{ skip }})
+    def test_start(self):
+        super().test_start()
     {% endif %}
 
     config = {{ config_chain_style }}
@@ -203,6 +217,15 @@ def make_config_chain_style(config: Dict) -> Text:
         config_chain_style += f'.export(*{config["export"]})'
 
     return config_chain_style
+
+
+def make_config_skip(config: Dict) -> Text:
+    if "skip" in config:
+        if config["skip"]:
+            config_chain_style = config["skip"]
+        else:
+            config_chain_style = '"skip unconditionally"'
+        return config_chain_style
 
 
 def make_request_chain_style(request: Dict) -> Text:
@@ -414,6 +437,7 @@ def make_testcase(testcase: Dict, dir_path: Text = None) -> Text:
         "class_name": f"TestCase{testcase_cls_name}",
         "imports_list": imports_list,
         "config_chain_style": make_config_chain_style(config),
+        "skip": make_config_skip(config),
         "parameters": config.get("parameters"),
         "teststeps_chain_style": [
             make_teststep_chain_style(step) for step in teststeps


### PR DESCRIPTION
使用示例:
```
config:
    name: "request methods testcase: reference testcase"
    variables:
        foo1: testsuite_config_bar1
        expect_foo1: testsuite_config_bar1
        expect_foo2: config_bar2
    base_url: "https://postman-echo.com"
    verify: False
    skip: '跳过原因,默认输出无条件跳过'
```