### PR TITLE
fix: panic occurred when the API step failed to run

### DIFF
--- a/hrp/step_api.go
+++ b/hrp/step_api.go
@@ -97,11 +97,11 @@ func (s *StepAPIWithOptionalArgs) Run(r *SessionRunner) (*StepResult, error) {
 	extendWithAPI(s.step, api)
 
 	stepResult, err := runStepRequest(r, s.step)
+	stepResult.StepType = stepTypeAPI
 	if err != nil {
 		r.summary.Success = false
-		return nil, err
+		return stepResult, err
 	}
-	stepResult.StepType = stepTypeAPI
 	return stepResult, nil
 }
 

--- a/httprunner/runner.py
+++ b/httprunner/runner.py
@@ -46,6 +46,7 @@ class SessionRunner(object):
     __export: List[Text] = []
     __step_results: List[StepResult] = []
     __session_variables: VariablesMapping = {}
+    __is_reference: bool = False
     # time
     __start_at: float = 0
     __duration: float = 0
@@ -58,6 +59,7 @@ class SessionRunner(object):
         self.__session_variables = self.__session_variables or {}
         self.__start_at = 0
         self.__duration = 0
+        self.__is_reference = self.__is_reference or False
 
         self.__project_meta = self.__project_meta or load_project_meta(
             self.__config.path
@@ -76,6 +78,10 @@ class SessionRunner(object):
 
     def get_config(self) -> TConfig:
         return self.__config
+
+    def set_references(self) -> "SessionRunner":
+        self.__is_reference = True
+        return self
 
     def with_case_id(self, case_id: Text) -> "SessionRunner":
         self.case_id = case_id
@@ -193,7 +199,7 @@ class SessionRunner(object):
                     )
                     time.sleep(step.retry_interval)
                     logger.info(
-                        f"run step retry ({i+1}/{step.retry_times} time): {step.name()} >>>>>>"
+                        f"run step retry ({i + 1}/{step.retry_times} time): {step.name()} >>>>>>"
                     )
 
         # save extracted variables to session variables
@@ -209,7 +215,7 @@ class SessionRunner(object):
         self.__init()
         self.__parse_config(param)
 
-        if USE_ALLURE:
+        if USE_ALLURE and not self.__is_reference:
             # update allure report meta
             allure.dynamic.title(self.__config.name)
             allure.dynamic.description(f"TestCase ID: {self.case_id}")

--- a/httprunner/step_testcase.py
+++ b/httprunner/step_testcase.py
@@ -22,7 +22,7 @@ def run_step_testcase(runner: HttpRunner, step: TStep) -> StepResult:
 
     # step.testcase is a referenced testcase, e.g. RequestWithFunctions
     ref_case_runner = step.testcase()
-    ref_case_runner.with_session(runner.session).with_case_id(
+    ref_case_runner.set_references().with_session(runner.session).with_case_id(
         runner.case_id
     ).with_variables(step_variables).with_export(step_export).test_start()
 


### PR DESCRIPTION
fix: panic occurred when the API step failed to run

修复因引用api断言失败而出现panic的问题

fix: step name overrides reference testcase name

修复前
![image](https://user-images.githubusercontent.com/43516634/174280080-c3fbc0c9-348c-42c4-86af-44ed08cbcddc.png)

修复后测试用例的name不会被引用的测试用例name所覆盖
![image](https://user-images.githubusercontent.com/43516634/174279909-fc41d18e-bd7d-4591-9d5b-f585df9f30be.png)
