### PR TITLE
fix: failed to load json/data content in api reference and ensure complete summary results

### DIFF
--- a/hrp/step_api.go
+++ b/hrp/step_api.go
@@ -47,7 +47,11 @@ func (path *APIPath) ToAPI() (*API, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 1. deal with request body compatibility
+	convertCompatRequestBody(api.Request)
+	// 2. deal with validators compatibility
 	err = convertCompatValidator(api.Validators)
+	// 3. deal with extract expr including hyphen
 	convertExtract(api.Extract)
 	return api, err
 }

--- a/hrp/testcase.go
+++ b/hrp/testcase.go
@@ -182,16 +182,7 @@ func (tc *TCase) MakeCompat() (err error) {
 	}()
 	for _, step := range tc.TestSteps {
 		// 1. deal with request body compatibility
-		if step.Request != nil && step.Request.Body == nil {
-			if step.Request.Json != nil {
-				step.Request.Headers["Content-Type"] = "application/json; charset=utf-8"
-				step.Request.Body = step.Request.Json
-				step.Request.Json = nil
-			} else if step.Request.Data != nil {
-				step.Request.Body = step.Request.Data
-				step.Request.Data = nil
-			}
-		}
+		convertCompatRequestBody(step.Request)
 
 		// 2. deal with validators compatibility
 		err = convertCompatValidator(step.Validators)
@@ -203,6 +194,19 @@ func (tc *TCase) MakeCompat() (err error) {
 		convertExtract(step.Extract)
 	}
 	return nil
+}
+
+func convertCompatRequestBody(request *Request) {
+	if request != nil && request.Body == nil {
+		if request.Json != nil {
+			request.Headers["Content-Type"] = "application/json; charset=utf-8"
+			request.Body = request.Json
+			request.Json = nil
+		} else if request.Data != nil {
+			request.Body = request.Data
+			request.Data = nil
+		}
+	}
 }
 
 func convertCompatValidator(Validators []interface{}) (err error) {

--- a/httprunner/runner.py
+++ b/httprunner/runner.py
@@ -67,7 +67,7 @@ class SessionRunner(object):
         self.root_dir = self.root_dir or self.__project_meta.RootDir
         self.__log_path = os.path.join(self.root_dir, "logs", f"{self.case_id}.run.log")
 
-        self.__step_results.clear()
+        self.__step_results = self.__step_results or []
         self.session = self.session or HttpSession()
         self.parser = self.parser or Parser(self.__project_meta.functions)
 

--- a/httprunner/step_request.py
+++ b/httprunner/step_request.py
@@ -81,6 +81,7 @@ def run_step_request(runner: HttpRunner, step: TStep) -> StepResult:
     """run teststep: request"""
     step_result = StepResult(
         name=step.name,
+        step_type="request",
         success=False,
     )
     start_time = time.time()

--- a/httprunner/step_sql_request.py
+++ b/httprunner/step_sql_request.py
@@ -47,6 +47,7 @@ def run_step_sql_request(runner: HttpRunner, step: TStep) -> StepResult:
 
     step_result = StepResult(
         name=step.name,
+        step_type="sql",
         success=False,
     )
     step_variables = runner.merge_step_variables(step.variables)

--- a/httprunner/step_testcase.py
+++ b/httprunner/step_testcase.py
@@ -10,7 +10,7 @@ from httprunner.step_request import call_hooks
 
 def run_step_testcase(runner: HttpRunner, step: TStep) -> StepResult:
     """run teststep: referenced testcase"""
-    step_result = StepResult(name=step.name)
+    step_result = StepResult(name=step.name, step_type="testcase")
     step_variables = runner.merge_step_variables(step.variables)
     step_export = step.export
 

--- a/httprunner/step_thrift_request.py
+++ b/httprunner/step_thrift_request.py
@@ -57,6 +57,7 @@ def run_step_thrift_request(runner: HttpRunner, step: TStep) -> StepResult:
 
     step_result = StepResult(
         name=step.name,
+        step_type="thrift",
         success=False,
     )
     step_variables = runner.merge_step_variables(step.variables)


### PR DESCRIPTION
1. fix: failed to load json/data content in api reference

问题：当前仅对testcase中的request body做了兼容性处理，如果用户在api中使用json字段来传数据会读取失败

2. fix: ensure complete summary results

问题：每次新创建的sessionRunner实例会共用一个__step_results，使用clear会清理掉之前保存的step_results

测试脚本：
```
from httprunner import HttpRunner, Config, Step, RunTestCase, Parameters, RunRequest


class DemoA(HttpRunner):
    url = '/home/pcweb/submit/mancardmenu'

    body = {"id": '100'}
    config = (
        Config("demo")
            .base_url('https://www.baidu.com')
    )

    teststeps = [
        Step(
            RunRequest("demo")
                .post(url)
                .with_json(body)
                .extract()
                .with_jmespath("status_code", 'code')
        )
    ]


class DemoB(HttpRunner):
    url = '/home/pcweb/submit/mancardmenu'

    body = {"id": '100'}
    config = (
        Config("demo")
            .base_url('https://www.baidu.com')
    )

    teststeps = [
        Step(
            RunRequest("demo")
                .post(url)
                .with_json(body)
        )
    ]


class TestDemo(HttpRunner):
    config = (
        Config("TestDemo")
            .base_url('https://www.baidu.com').export('code')
    )

    def test_start(self, params=None):
        super().test_start()
        print('1. get_export_variables', self.get_export_variables())  # 打印为空
        summary = self.get_summary()
        print('summary', summary)
        # 只写case A可以打印出来，如果后面加上case B则打印为空

    teststeps = [
        Step(
            RunTestCase("case A")
                .call(DemoA)
                .export('code')
        ),
        Step(
            RunTestCase("case B")
                .call(DemoB)
        )
    ]

```

修改前：
![image](https://user-images.githubusercontent.com/43516634/174555167-8cf87520-a132-4522-8d5e-3f33abf7bff9.png)

修改后：
![image](https://user-images.githubusercontent.com/43516634/174554999-4aeb558e-829b-402f-92bf-26b3fe8ab2cf.png)

3. fix: add the step type to the summary step result

在summary中补充step type信息
![image](https://user-images.githubusercontent.com/43516634/174555653-df60eacc-75c6-4dd7-a8fe-b9186897636a.png)
