### PR TITLE
fix: reset the testcase config when initializing SessionRunner

### DIFF
--- a/httprunner/config.py
+++ b/httprunner/config.py
@@ -1,7 +1,8 @@
+import copy
 import inspect
 from typing import Text
 
-from httprunner.models import TConfig, TConfigThrift, TConfigDB, ProtoType
+from httprunner.models import TConfig, TConfigThrift, TConfigDB, ProtoType, VariablesMapping
 
 
 class ConfigThrift(object):
@@ -89,6 +90,9 @@ class ConfigDB(object):
 class Config(object):
     def __init__(self, name: Text) -> None:
         caller_frame = inspect.stack()[1]
+        self.__name: Text = name
+        self.__base_url: Text = ""
+        self.__variables: VariablesMapping = {}
         self.__config = TConfig(name=name, path=caller_frame.filename)
 
     @property
@@ -100,11 +104,11 @@ class Config(object):
         return self.__config.path
 
     def variables(self, **variables) -> "Config":
-        self.__config.variables.update(variables)
+        self.__variables.update(variables)
         return self
 
     def base_url(self, base_url: Text) -> "Config":
-        self.__config.base_url = base_url
+        self.__base_url = base_url
         return self
 
     def verify(self, verify: bool) -> "Config":
@@ -117,10 +121,18 @@ class Config(object):
         return self
 
     def struct(self) -> TConfig:
+        self.__init()
         return self.__config
 
     def thrift(self) -> ConfigThrift:
+        self.__init()
         return ConfigThrift(self.__config)
 
     def db(self) -> ConfigDB:
+        self.__init()
         return ConfigDB(self.__config)
+
+    def __init(self) -> None:
+        self.__config.name = self.__name
+        self.__config.base_url = self.__base_url
+        self.__config.variables = copy.copy(self.__variables)


### PR DESCRIPTION
### python版本

#### 问题
在测试用例config中如果引用参数驱动设置的参数，每次迭代仅能引用到第一个参数

#### 原因
__config中的base_url、variables、name等变量在每次迭代时都不会被重置，使用__parse_config函数解析一次后，后续迭代都将是第一次解析后的参数

#### 更改
Config类新增存未解析的成员变量，在config.struct()函数返回__config前，使用未解析的成员变量对__config进行重置，避免再次迭代时，解析已解析过后的变量而引用参数失败

#### 测试场景
```
     @pytest.mark.parametrize(
        "param",
        Parameters(
            {
                "base_url": ["https://www.baidu.com", "https://www.postman_echo.com"]
            }
        ),
    )
    def test_start(self, param):
        super().test_start(param)

    config = (
        Config("request methods testcase: testcase")
        .variables(
            **{
                "foo1": "testsuite_config_bar1",
                "expect_foo1": "testsuite_config_bar1",
                "expect_foo2": "config_bar2",
            }
        )
        .base_url("$base_url")
        .verify(False)
    )
```
