### PR TITLE
feat: add filename/type when uploading form-data

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release History
 
-## v4.1.7 (2022-07-11)
+## v4.1.7 (2022-07-18)
 
 **go version**
 
+- fix: using '@FILEPATH' to indicate the path of the file 
 - feat: support indicating type and filename when uploading file
+- feat: support to infer MIME type of the file automatically
 
 
 ## v4.1.6 (2022-07-04)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## v4.1.7 (2022-07-11)
+
+**go version**
+
+- feat: support indicating type and filename when uploading file
+
+
 ## v4.1.6 (2022-07-04)
 
 **go version**

--- a/hrp/internal/builtin/function.go
+++ b/hrp/internal/builtin/function.go
@@ -77,16 +77,16 @@ type TFormDataWriter struct {
 	Payload *bytes.Buffer
 }
 
-func (w *TFormDataWriter) writeCustomField(formKey, formValue, formType, formFileName string) error {
+func (w *TFormDataWriter) writeCustomText(formKey, formValue, formType, formFileName string) error {
 	if w.Writer == nil {
 		return errors.New("form-data writer not initialized")
 	}
 	h := make(textproto.MIMEHeader)
-	// field doesn't have Content-Type by default
+	// text doesn't have Content-Type by default
 	if formType != "" {
 		h.Set("Content-Type", formType)
 	}
-	// field doesn't have filename in Content-Disposition by default
+	// text doesn't have filename in Content-Disposition by default
 	if formFileName == "" {
 		h.Set("Content-Disposition",
 			fmt.Sprintf(`form-data; name="%s"`, escapeQuotes(formKey)))
@@ -193,7 +193,7 @@ func multipartEncoder(formMap map[string]interface{}) (*TFormDataWriter, error) 
 			}
 			continue
 		}
-		if err := tFormWriter.writeCustomField(formKey, formValue, formType, formFileName); err != nil {
+		if err := tFormWriter.writeCustomText(formKey, formValue, formType, formFileName); err != nil {
 			log.Error().Err(err).Msgf("failed to write text: %v=%v, ignore", formKey, formValue)
 			return nil, err
 		}

--- a/hrp/response.go
+++ b/hrp/response.go
@@ -130,7 +130,7 @@ func (v *responseObject) searchField(field string, variablesMapping map[string]i
 		var err error
 		result, err = v.parser.Parse(field, variablesMapping)
 		if err != nil {
-			log.Error().Str("filed name", field).Err(err).Msg("fail to parse field before search")
+			log.Error().Str("field name", field).Err(err).Msg("fail to parse field before search")
 		}
 	}
 	// search field using jmespath or regex if parsed field is still string and contains specified fieldTags

--- a/hrp/step_api.go
+++ b/hrp/step_api.go
@@ -2,6 +2,7 @@ package hrp
 
 import (
 	"fmt"
+
 	"github.com/jinzhu/copier"
 	"github.com/rs/zerolog/log"
 
@@ -126,7 +127,7 @@ func extendWithAPI(testStep *TStep, overriddenStep *API) {
 	// merge & override request
 	testStep.Request = overriddenStep.Request
 	// init upload
-	if testStep.Request.Upload != nil {
+	if len(testStep.Request.Upload) != 0 {
 		initUpload(testStep)
 	}
 	// merge & override variables

--- a/hrp/step_request.go
+++ b/hrp/step_request.go
@@ -268,7 +268,7 @@ func initUpload(step *TStep) {
 }
 
 func prepareUpload(parser *Parser, step *TStep, stepVariables map[string]interface{}) (err error) {
-	if step.Request.Upload == nil {
+	if len(step.Request.Upload) == 0 {
 		return
 	}
 	uploadMap, err := parser.Parse(step.Request.Upload, stepVariables)

--- a/hrp/step_request.go
+++ b/hrp/step_request.go
@@ -247,7 +247,7 @@ func (r *requestBuilder) prepareBody(stepVariables map[string]interface{}) error
 		dataBytes = vv
 	case bytes.Buffer:
 		dataBytes = vv.Bytes()
-	case *builtin.TFormWriter:
+	case *builtin.TFormDataWriter:
 		dataBytes = vv.Payload.Bytes()
 	default: // unexpected body type
 		return errors.New("unexpected request body type")

--- a/hrp/testcase.go
+++ b/hrp/testcase.go
@@ -148,7 +148,7 @@ func (path *TestCasePath) ToTestCase() (*TestCase, error) {
 			})
 		} else if step.Request != nil {
 			// init upload
-			if step.Request.Upload != nil {
+			if len(step.Request.Upload) != 0 {
 				initUpload(step)
 			}
 			testCase.TestSteps = append(testCase.TestSteps, &StepRequestWithOptionalArgs{


### PR DESCRIPTION
## 主要修改

- fix: 使用 `@FILEPATH` 的固定模式来指定要上传的文件路径
- feat: 上传文件时支持手动指定文件 MIME 类型和名称
- feat: 支持根据文件拓展名自动识别文件 MIME 类型

## 使用方式

在用于上传文件的 `upload ` 字段中，当且仅当 map 的值以 @ 开头，例如 `@"FILEPATH"` 或 `@FILEPATH` 的形式时，程序会尝试加载 `FILEPATH ` 所指向的文件，并以 form-data 的形式上传。另外，支持在文件路径的后面增加` filename=xxx `和` type=xxx `选项用于配置 MIME 头域信息，选项和文件路径之间用分号 ‘;‘ 分隔开。

如果 map 值不为文件路径而是普通文本时，程序会自动去除文本最外层包裹的双引号，例如传递的文本为 `"@DUMMYPATH"` 时，实际传递给服务端的是 `@DUMMYPATH`

**注意**

当 map 值为普通文本时，`filename` 和 `type` 选项依然会生效。

下面给出一个完整的测试用例：

```json
{
    "config": {
        "name": "test upload file to httpbin",
        "base_url": "http://httpbin.org",
        "variables": {
            "upload_file": "test.env"
        }
    },
    "teststeps": [
        {
            "name": "upload field string with filename and type",
            "request": {
                "method": "POST",
                "url": "/post",
                "headers": {
                    "Content-Type": "${multipart_content_type($m_encoder)}"
                },
                "body": "$m_encoder",
                "upload": {
                    "foo1": "bar1",
                    "foo2": "@\"$upload_file\";filename=newBar2;type=text/plain"
                }
            },
            "validate": [
                {
                    "check": "status_code",
                    "assert": "equals",
                    "expect": 200,
                    "msg": "check status code"
                },
                {
                    "check": "body.form.foo1",
                    "assert": "startswith",
                    "expect": "bar1",
                    "msg": "check foo1 in form"
                },
                {
                    "check": "body.files.foo2",
                    "assert": "startswith",
                    "expect": "UserName=test",
                    "msg": "check foo2 in files"
                }
            ]
        }
    ]
}

```

## 抓包自测

使用 hrp 运行上面的测试用例，并使用 wireshark 的抓包结果如下：

![image](https://user-images.githubusercontent.com/41049280/177270972-e06b4348-b85a-482c-b812-bd2f0bd9d3c0.png)
