### PR TITLE
fix: reuse plugin instance if it already initialized

### DIFF
--- a/hrp/plugin.go
+++ b/hrp/plugin.go
@@ -27,6 +27,8 @@ const (
 
 const projectInfoFile = "proj.json" // used for ensuring root project
 
+var pluginMap = map[string]funplugin.IPlugin{} // used for reusing plugin instance
+
 func initPlugin(path, venv string, logOn bool) (plugin funplugin.IPlugin, err error) {
 	// plugin file not found
 	if path == "" {
@@ -35,6 +37,11 @@ func initPlugin(path, venv string, logOn bool) (plugin funplugin.IPlugin, err er
 	pluginPath, err := locatePlugin(path)
 	if err != nil {
 		return nil, nil
+	}
+
+	// reuse plugin instance if it already initialized
+	if p, ok := pluginMap[pluginPath]; ok {
+		return p, nil
 	}
 
 	pluginOptions := []funplugin.Option{funplugin.WithLogOn(logOn)}
@@ -68,6 +75,9 @@ func initPlugin(path, venv string, logOn bool) (plugin funplugin.IPlugin, err er
 		log.Error().Err(err).Msgf("init plugin failed: %s", pluginPath)
 		return
 	}
+
+	// add plugin instance to plugin map
+	pluginMap[pluginPath] = plugin
 
 	// catch Interrupt and SIGTERM signals to ensure plugin quitted
 	c := make(chan os.Signal)

--- a/hrp/runner_test.go
+++ b/hrp/runner_test.go
@@ -3,6 +3,7 @@ package hrp
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -22,6 +23,8 @@ func buildHashicorpGoPlugin() {
 func removeHashicorpGoPlugin() {
 	log.Info().Msg("[teardown] remove hashicorp go plugin")
 	os.Remove(tmpl("debugtalk.bin"))
+	pluginPath, _ := filepath.Abs(tmpl("debugtalk.bin"))
+	delete(pluginMap, pluginPath)
 }
 
 func buildHashicorpPyPlugin() {


### PR DESCRIPTION
### [fix: reuse plugin instance if it already initialized](https://github.com/httprunner/httprunner/commit/6dcb17148a39b0c9de34ca6ebdefcd4f3194a63d)

当测试用例存在测试用例引用的时候，每跑一次测试用例引用都会新建一个plugin实例，由于实例只能测试结束才能销毁，所以在长时间压测的情况下，会造成系统文件描述符占满、以及内存大量占用问题

修复前：
![image](https://user-images.githubusercontent.com/43516634/177328973-b3f22e07-d9e5-4480-9824-b6bde7290039.png)

修复后：
![image](https://user-images.githubusercontent.com/43516634/177329086-44908063-522e-4eb0-8da5-8946254bc1e8.png)


### [fix: deep copy api step to avoid data racing](https://github.com/httprunner/httprunner/commit/912fb7b3510f58d9781674bf065c8d833257d949)

当前在运行时，run api step时会直接修改测试用例的step，出现数据竞争问题