### PR TITLE
support custom requests.Response attr.

### DIFF
--- a/httprunner/parser.py
+++ b/httprunner/parser.py
@@ -16,7 +16,7 @@ dolloar_regex_compile = re.compile(r"\$\$")
 # variable should start with a-zA-Z_
 variable_regex_compile = re.compile(r"\$\{([a-zA-Z_]\w*)\}|\$([a-zA-Z_]\w*)")
 # function notation, e.g. ${func1($var_1, $var_3)}
-function_regex_compile = re.compile(r"\$\{([a-zA-Z_]\w*)\(([\$\w\.\-/\s=,]*)\)\}")
+function_regex_compile = re.compile(r"\$\{([a-zA-Z_]\w*)\(([\$\w\.\-/\s\S=,]*)\)\}")
 
 
 def parse_string_value(str_value: Text) -> Any:

--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -282,7 +282,10 @@ class ResponseObject(ResponseObjectBase):
             "body": self.body,
         }
         if not expr.startswith(tuple(resp_obj_meta.keys())):
-            return expr
+            if hasattr(self.resp_obj,expr):
+                return getattr(self.resp_obj,expr)
+            else:
+                return expr
 
         try:
             check_value = jmespath.search(expr, resp_obj_meta)


### PR DESCRIPTION
目前在debugtalk的自定义方法中，如果需要增加response属性来进行断言判断，不能获取到增加的属性值。这样修改的话，可以在用例断言中，使用自定义的response属性。

![1657068935850](https://user-images.githubusercontent.com/36434225/177440341-574b68ae-02f5-4195-a3f8-6cf4857bf038.jpg)
![image](https://user-images.githubusercontent.com/36434225/177440397-a8bc6291-b04b-43f8-8460-1c21ccdb8532.png)
