### PR TITLE
feat: net/http supports the use of incoming Host

### DIFF
--- a/hrp/config.go
+++ b/hrp/config.go
@@ -21,8 +21,9 @@ func NewConfig(name string) *TConfig {
 type TConfig struct {
 	Name              string                 `json:"name" yaml:"name"` // required
 	Verify            bool                   `json:"verify,omitempty" yaml:"verify,omitempty"`
-	BaseURL           string                 `json:"base_url,omitempty" yaml:"base_url,omitempty"`   // deprecated in v4.1, moved to env
-	Headers           map[string]string      `json:"headers,omitempty" yaml:"headers,omitempty"`     // public request headers
+	BaseURL           string                 `json:"base_url,omitempty" yaml:"base_url,omitempty"` // deprecated in v4.1, moved to env
+	Headers           map[string]string      `json:"headers,omitempty" yaml:"headers,omitempty"`   // public request headers
+	UseHeaderHost     bool                   `json:"use_header_host,omitempty" yaml:"use_header_host,omitempty"`
 	Environs          map[string]string      `json:"environs,omitempty" yaml:"environs,omitempty"`   // environment variables
 	Variables         map[string]interface{} `json:"variables,omitempty" yaml:"variables,omitempty"` // global variables
 	Parameters        map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`

--- a/hrp/runner.go
+++ b/hrp/runner.go
@@ -382,6 +382,8 @@ func (r *testCaseRunner) parseConfig() error {
 	}
 	r.parametersIterator = parametersIterator
 
+	r.parsedConfig.UseHeaderHost = cfg.UseHeaderHost
+
 	return nil
 }
 

--- a/hrp/step_request.go
+++ b/hrp/step_request.go
@@ -110,7 +110,7 @@ func (r *requestBuilder) prepareHeaders(stepVariables map[string]interface{}) er
 
 			// supports the use of incoming Host
 			if key == "useIncomingHost" {
-				r.req.Host = headers[value]
+				r.req.Host = value
 				continue
 			}
 

--- a/hrp/step_request.go
+++ b/hrp/step_request.go
@@ -108,12 +108,6 @@ func (r *requestBuilder) prepareHeaders(stepVariables map[string]interface{}) er
 				continue
 			}
 
-			// supports the use of incoming Host
-			if key == "useIncomingHost" {
-				r.req.Host = value
-				continue
-			}
-
 			r.req.Header.Add(key, value)
 
 			// prepare content length
@@ -122,6 +116,11 @@ func (r *requestBuilder) prepareHeaders(stepVariables map[string]interface{}) er
 					r.req.ContentLength = l
 				}
 			}
+		}
+
+		// set Host of Header Host
+		if r.config.UseHeaderHost && headers["Host"] != "" {
+			r.req.Host = headers["Host"]
 		}
 	}
 

--- a/hrp/step_request.go
+++ b/hrp/step_request.go
@@ -107,6 +107,13 @@ func (r *requestBuilder) prepareHeaders(stepVariables map[string]interface{}) er
 			if strings.HasPrefix(key, ":") {
 				continue
 			}
+
+			// supports the use of incoming Host
+			if key == "useIncomingHost" {
+				r.req.Host = headers[value]
+				continue
+			}
+
 			r.req.Header.Add(key, value)
 
 			// prepare content length


### PR DESCRIPTION
在net/http中，利用req.Header.Set()或req.Header.Add()方法无法设置Host的值，可以在http包的request.go文件Header的声明注释内看到:
// For incoming requests, the Host header is promoted to the
// Request.Host field and removed from the Header map.

需要利用Request.Host来设置Host值

为兼容对不使用此功能的用户的未知影响，用特定header头useIncomingHost来标识