### PR TITLE
fix: hrp boom --run-time setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## v4.2.1 (2022-09-01)
+
+**go version**
+
+- fix: hrp boom duration still limited without specifying `--run-time`
+
 ## v4.2.0 (2022-08-21)
 
 **go version**


### PR DESCRIPTION
## Main Changes
1. 修复未指定压测时间 `--run-time` 时，`hrp boom` 默认只持续最多3s的问题
2. 提升 `--run-time` 到期时间的检测频率（3s 一次改为 1s 一次）