### PR TITLE
fix: failed to parse $device_udid in testcase

### DIFF
--- a/hrp/runner.go
+++ b/hrp/runner.go
@@ -390,12 +390,26 @@ func (r *testCaseRunner) parseConfig() error {
 
 	// init iOS/Android clients
 	for _, iosDeviceConfig := range r.parsedConfig.IOS {
+		if iosDeviceConfig.UDID != "" {
+			udid, err := r.parser.ParseString(iosDeviceConfig.UDID, parsedVariables)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse ios device udid")
+			}
+			iosDeviceConfig.UDID = udid.(string)
+		}
 		_, err := r.hrpRunner.initUIClient(iosDeviceConfig)
 		if err != nil {
 			return errors.Wrap(err, "init iOS WDA client failed")
 		}
 	}
 	for _, androidDeviceConfig := range r.parsedConfig.Android {
+		if androidDeviceConfig.SerialNumber != "" {
+			sn, err := r.parser.ParseString(androidDeviceConfig.SerialNumber, parsedVariables)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse android device serial")
+			}
+			androidDeviceConfig.SerialNumber = sn.(string)
+		}
 		_, err := r.hrpRunner.initUIClient(androidDeviceConfig)
 		if err != nil {
 			return errors.Wrap(err, "init Android UIAutomator client failed")

--- a/hrp/step_android_ui.go
+++ b/hrp/step_android_ui.go
@@ -503,6 +503,15 @@ func runStepAndroid(s *SessionRunner, step *TStep) (stepResult *StepResult, err 
 	}
 	parser := s.GetParser()
 
+	// parse device serial
+	if step.Android.AndroidDevice.SerialNumber != "" {
+		sn, err := parser.ParseString(step.Android.AndroidDevice.SerialNumber, stepVariables)
+		if err != nil {
+			return stepResult, err
+		}
+		step.Android.AndroidDevice.SerialNumber = sn.(string)
+	}
+
 	// init uiaClient driver
 	uiaClient, err := s.hrpRunner.initUIClient(&step.Android.AndroidDevice)
 	if err != nil {

--- a/hrp/step_ios_ui.go
+++ b/hrp/step_ios_ui.go
@@ -524,6 +524,15 @@ func runStepIOS(s *SessionRunner, step *TStep) (stepResult *StepResult, err erro
 	}
 	parser := s.GetParser()
 
+	// parse device udid
+	if step.IOS.IOSDevice.UDID != "" {
+		udid, err := parser.ParseString(step.IOS.IOSDevice.UDID, stepVariables)
+		if err != nil {
+			return stepResult, err
+		}
+		step.IOS.IOSDevice.UDID = udid.(string)
+	}
+
 	// init wdaClient driver
 	wdaClient, err := s.hrpRunner.initUIClient(&step.IOS.IOSDevice)
 	if err != nil {


### PR DESCRIPTION
支持在android与ios自动化测试用例中l使用$解析udid或serial的引用参数
![image](https://user-images.githubusercontent.com/43516634/194698252-5efafd56-968a-4f84-b101-c6ac1b8b8941.png)
