### PR TITLE
通过单例实现initplugin，修复用例引用问题，防止重复创建plugin

### DIFF
--- a/hrp/plugin.go
+++ b/hrp/plugin.go
@@ -30,90 +30,93 @@ const (
 const projectInfoFile = "proj.json" // used for ensuring root project
 
 var pluginMap = sync.Map{} // used for reusing plugin instance
-var pluginRW = make(map[string]*funplugin.IPlugin)
+var pluginMapRW = make(map[string]*funplugin.IPlugin)
 var pluginMutex sync.RWMutex
 
 func initPlugin(path, venv string, logOn bool) (plugin funplugin.IPlugin, err error) {
 	pluginMutex.RLock()
-	plugins := pluginRW[path]
+	plugins := pluginMapRW[path]
 	pluginMutex.RUnlock()
 	if plugins == nil {
 		pluginMutex.Lock()
 		defer pluginMutex.Unlock()
+		plugins = pluginMapRW[path]
 		if plugins == nil {
-			plugin, err = func(path, venv string, logOn bool) (plugin funplugin.IPlugin, err error) {
-				// plugin file not found
-				if path == "" {
-					return nil, nil
-				}
-				pluginPath, err := locatePlugin(path)
-				if err != nil {
-					log.Warn().Str("path", path).Msg("locate plugin failed")
-					return nil, nil
-				}
-
-				// reuse plugin instance if it already initialized
-				if p, ok := pluginMap.Load(pluginPath); ok {
-					return p.(funplugin.IPlugin), nil
-				}
-
-				pluginOptions := []funplugin.Option{funplugin.WithLogOn(logOn)}
-
-				if strings.HasSuffix(pluginPath, ".py") {
-					// register funppy plugin
-					genPyPluginPath := filepath.Join(filepath.Dir(pluginPath), PluginPySourceGenFile)
-					err = BuildPlugin(pluginPath, genPyPluginPath)
-					if err != nil {
-						log.Error().Err(err).Str("path", pluginPath).Msg("build plugin failed")
-						return nil, err
-					}
-					pluginPath = genPyPluginPath
-
-					packages := []string{
-						fmt.Sprintf("funppy==%s", fungo.Version),
-					}
-					python3, err := myexec.EnsurePython3Venv(venv, packages...)
-					if err != nil {
-						log.Error().Err(err).
-							Interface("packages", packages).
-							Msg("python3 venv is not ready")
-						return nil, err
-					}
-					pluginOptions = append(pluginOptions, funplugin.WithPython3(python3))
-				}
-
-				// found plugin file
-				plugin, err = funplugin.Init(pluginPath, pluginOptions...)
-				if err != nil {
-					log.Error().Err(err).Msgf("init plugin failed: %s", pluginPath)
-					err = errors.Wrap(code.InitPluginFailed, err.Error())
-					return
-				}
-
-				// add plugin instance to plugin map
-				pluginMap.Store(pluginPath, plugin)
-
-				// report event for initializing plugin
-				event := sdk.EventTracking{
-					Category: "InitPlugin",
-					Action:   fmt.Sprintf("Init %s plugin", plugin.Type()),
-					Value:    0, // success
-				}
-				if err != nil {
-					event.Value = 1 // failed
-				}
-				go sdk.SendEvent(event)
-
-				return
-			}(path, venv, logOn)
+			plugin, err = initplugin(path, venv, logOn)
 			if err != nil {
 				return nil, errors.Wrap(err, "init plugin failed")
 			}
-			pluginRW[path] = &plugin
+			pluginMapRW[path] = &plugin
 			plugins = &plugin
 		}
 	}
 	return *plugins, nil
+}
+
+func initplugin(path, venv string, logOn bool) (plugin funplugin.IPlugin, err error) {
+	// plugin file not found
+	if path == "" {
+		return nil, nil
+	}
+	pluginPath, err := locatePlugin(path)
+	if err != nil {
+		log.Warn().Str("path", path).Msg("locate plugin failed")
+		return nil, nil
+	}
+
+	// reuse plugin instance if it already initialized
+	if p, ok := pluginMap.Load(pluginPath); ok {
+		return p.(funplugin.IPlugin), nil
+	}
+
+	pluginOptions := []funplugin.Option{funplugin.WithLogOn(logOn)}
+
+	if strings.HasSuffix(pluginPath, ".py") {
+		// register funppy plugin
+		genPyPluginPath := filepath.Join(filepath.Dir(pluginPath), PluginPySourceGenFile)
+		err = BuildPlugin(pluginPath, genPyPluginPath)
+		if err != nil {
+			log.Error().Err(err).Str("path", pluginPath).Msg("build plugin failed")
+			return nil, err
+		}
+		pluginPath = genPyPluginPath
+
+		packages := []string{
+			fmt.Sprintf("funppy==%s", fungo.Version),
+		}
+		python3, err := myexec.EnsurePython3Venv(venv, packages...)
+		if err != nil {
+			log.Error().Err(err).
+				Interface("packages", packages).
+				Msg("python3 venv is not ready")
+			return nil, err
+		}
+		pluginOptions = append(pluginOptions, funplugin.WithPython3(python3))
+	}
+
+	// found plugin file
+	plugin, err = funplugin.Init(pluginPath, pluginOptions...)
+	if err != nil {
+		log.Error().Err(err).Msgf("init plugin failed: %s", pluginPath)
+		err = errors.Wrap(code.InitPluginFailed, err.Error())
+		return
+	}
+
+	// add plugin instance to plugin map
+	pluginMap.Store(pluginPath, plugin)
+
+	// report event for initializing plugin
+	event := sdk.EventTracking{
+		Category: "InitPlugin",
+		Action:   fmt.Sprintf("Init %s plugin", plugin.Type()),
+		Value:    0, // success
+	}
+	if err != nil {
+		event.Value = 1 // failed
+	}
+	go sdk.SendEvent(event)
+
+	return
 }
 
 func locatePlugin(path string) (pluginPath string, err error) {


### PR DESCRIPTION
测试用例引用testcase时会出现每次调用testcase都会实例化一个plugin，导致性能测试时引用testcase出现实例化n个plugin，大量消耗cpu，导致性能数据不准确
解决方案：
1、不同的用例，可以使用不同的debugtalk.py文件
2、调用initPlugin时做读写锁操作，由于兼容不同的用例使用不同的debugtalk.py，所以无法用once.do的操作
