### PR TITLE
fix: err wrap and TapFloat

### DIFF
--- a/hrp/pkg/uixt/android_adb_driver.go
+++ b/hrp/pkg/uixt/android_adb_driver.go
@@ -180,6 +180,13 @@ func (ad *adbDriver) Tap(x, y int, options ...DataOption) error {
 }
 
 func (ad *adbDriver) TapFloat(x, y float64, options ...DataOption) (err error) {
+	dataOptions := NewDataOptions(options...)
+
+	if len(dataOptions.Offset) == 2 {
+		x += float64(dataOptions.Offset[0])
+		y += float64(dataOptions.Offset[1])
+	}
+
 	// adb shell input tap x y
 	_, err = ad.adbClient.RunShellCommand(
 		"input", "tap", fmt.Sprintf("%.1f", x), fmt.Sprintf("%.1f", y))

--- a/hrp/runner.go
+++ b/hrp/runner.go
@@ -559,7 +559,7 @@ func (r *SessionRunner) Start(givenVars map[string]interface{}) error {
 
 		// check if failfast
 		if r.caseRunner.hrpRunner.failfast {
-			return errors.New("abort running due to failfast setting")
+			return errors.Wrap(err, "abort running due to failfast setting")
 		}
 	}
 


### PR DESCRIPTION
## Main Changes
1. 修复测试用例跑不通过 failfast 时，shell 退出码始终为 1 的问题
2. 修复 adb 驱动，TapFloat 方法 options 未使用的问题