### PR TITLE
fix: report html display the value of the url instead of variables

### DIFF
--- a/hrp/step_request.go
+++ b/hrp/step_request.go
@@ -187,6 +187,9 @@ func (r *requestBuilder) prepareUrlParams(stepVariables map[string]interface{}) 
 	r.req.URL = u
 	r.req.Host = u.Host
 
+	// update url
+	r.requestMap["url"] = u
+
 	return nil
 }
 


### PR DESCRIPTION
只修复了 url 的显示问题，对于 #1468  说的另一个body问题，不归为显示问题。