### PR TITLE
support to sleep n seconds after the start of last action

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## v4.3.5 (2023-07-04)
+
+**go version**
+
+- feat: add `sleep_strcit` to sleep n seconds after the start of last action
+
 ## v4.3.4 (2023-06-01)
 
 **go version**

--- a/examples/uitest/demo_android_naive_sleep.json
+++ b/examples/uitest/demo_android_naive_sleep.json
@@ -1,0 +1,68 @@
+{
+    "config": {
+        "name": "浏览器时间戳截图",
+        "variables": {
+            "device": "${ENV(SerialNumber)}"
+        },
+        "android": [
+            {
+                "serial": "$device"
+            }
+        ]
+    },
+    "teststeps": [
+        {
+            "name": "打开浏览器local-time时间戳界面",
+            "android": {
+                "actions": [
+                    {
+                        "method": "home"
+                    },
+                    {
+                        "method": "swipe_to_tap_app",
+                        "params": "local",
+                        "options": {
+                            "max_retry_times": 5
+                        }
+                    },
+                    {
+                        "method": "sleep",
+                        "params": 7
+                    }
+                ]
+            }
+        },
+        {
+            "name": "循环2次，每次截图四张，截图间隔为1s/2s/3s",
+            "android": {
+                "actions": [
+                    {
+                        "method": "screenshot"
+                    },
+                    {
+                        "method": "sleep",
+                        "params": 1
+                    },
+                    {
+                        "method": "screenshot"
+                    },
+                    {
+                        "method": "sleep",
+                        "params": 2
+                    },
+                    {
+                        "method": "screenshot"
+                    },
+                    {
+                        "method": "sleep",
+                        "params": 3
+                    },
+                    {
+                        "method": "screenshot"
+                    }
+                ]
+            },
+            "loops": 2
+        }
+    ]
+}

--- a/examples/uitest/demo_android_sleep_test.go
+++ b/examples/uitest/demo_android_sleep_test.go
@@ -1,0 +1,74 @@
+package uitest
+
+import (
+	"testing"
+
+	"github.com/httprunner/httprunner/v4/hrp"
+	"github.com/httprunner/httprunner/v4/hrp/pkg/uixt"
+)
+
+func TestAndroidNaiveSleep(t *testing.T) {
+	testCase := &hrp.TestCase{
+		Config: hrp.NewConfig("浏览器时间戳截图").
+			WithVariables(map[string]interface{}{
+				"device": "${ENV(SerialNumber)}",
+			}).
+			SetAndroid(uixt.WithSerialNumber("$device")),
+		TestSteps: []hrp.IStep{
+			hrp.NewStep("打开浏览器local-time时间戳界面").
+				Android().
+				Home().
+				SwipeToTapApp("local", uixt.WithMaxRetryTimes(5)).
+				Sleep(7),
+			hrp.NewStep("循环2次，每次截图四张，截图间隔为1s/2s/3s").
+				Loop(2).
+				Android().
+				ScreenShot().Sleep(1).
+				ScreenShot().Sleep(2).
+				ScreenShot().Sleep(3).
+				ScreenShot(),
+		},
+	}
+
+	if err := testCase.Dump2JSON("demo_android_naive_sleep.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	// err := hrp.Run(t, testCase)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+}
+
+func TestAndroidStrictSleep(t *testing.T) {
+	testCase := &hrp.TestCase{
+		Config: hrp.NewConfig("浏览器时间戳截图").
+			WithVariables(map[string]interface{}{
+				"device": "${ENV(SerialNumber)}",
+			}).
+			SetAndroid(uixt.WithSerialNumber("$device")),
+		TestSteps: []hrp.IStep{
+			hrp.NewStep("打开浏览器local-time时间戳界面").
+				Android().
+				Home().
+				SwipeToTapApp("local", uixt.WithMaxRetryTimes(5)).
+				Sleep(7),
+			hrp.NewStep("循环2次，每次截图四张，截图间隔为1s/2s/3s").
+				Loop(2).
+				Android().
+				ScreenShot().SleepStrict(1).
+				ScreenShot().SleepStrict(2).
+				ScreenShot().SleepStrict(3).
+				ScreenShot(),
+		},
+	}
+
+	if err := testCase.Dump2JSON("demo_android_strict_sleep.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	// err := hrp.Run(t, testCase)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+}

--- a/examples/uitest/demo_android_strict_sleep.json
+++ b/examples/uitest/demo_android_strict_sleep.json
@@ -1,0 +1,68 @@
+{
+    "config": {
+        "name": "浏览器时间戳截图",
+        "variables": {
+            "device": "${ENV(SerialNumber)}"
+        },
+        "android": [
+            {
+                "serial": "$device"
+            }
+        ]
+    },
+    "teststeps": [
+        {
+            "name": "打开浏览器local-time时间戳界面",
+            "android": {
+                "actions": [
+                    {
+                        "method": "home"
+                    },
+                    {
+                        "method": "swipe_to_tap_app",
+                        "params": "local",
+                        "options": {
+                            "max_retry_times": 5
+                        }
+                    },
+                    {
+                        "method": "sleep",
+                        "params": 7
+                    }
+                ]
+            }
+        },
+        {
+            "name": "循环2次，每次截图四张，截图间隔为1s/2s/3s",
+            "android": {
+                "actions": [
+                    {
+                        "method": "screenshot"
+                    },
+                    {
+                        "method": "sleep_strict",
+                        "params": 1
+                    },
+                    {
+                        "method": "screenshot"
+                    },
+                    {
+                        "method": "sleep_strict",
+                        "params": 2
+                    },
+                    {
+                        "method": "screenshot"
+                    },
+                    {
+                        "method": "sleep_strict",
+                        "params": 3
+                    },
+                    {
+                        "method": "screenshot"
+                    }
+                ]
+            },
+            "loops": 2
+        }
+    ]
+}

--- a/hrp/internal/builtin/utils.go
+++ b/hrp/internal/builtin/utils.go
@@ -448,5 +448,5 @@ func GenNameWithTimestamp(tmpl string) string {
 	if !strings.Contains(tmpl, "%d") {
 		tmpl = tmpl + "_%d"
 	}
-	return fmt.Sprintf(tmpl, time.Now().Unix())
+	return fmt.Sprintf(tmpl, time.Now().UnixNano()/1e6)
 }

--- a/hrp/pkg/uixt/ext.go
+++ b/hrp/pkg/uixt/ext.go
@@ -91,6 +91,7 @@ type DriverExt struct {
 
 	// cache step data
 	cacheStepData cacheStepData
+	lastStartTime time.Time
 }
 
 func NewDriverExt(device Device, driver WebDriver) (dExt *DriverExt, err error) {

--- a/hrp/step_mobile_ui.go
+++ b/hrp/step_mobile_ui.go
@@ -256,10 +256,22 @@ func (s *StepMobile) Input(text string, options ...uixt.ActionOption) *StepMobil
 	return &StepMobile{step: s.step}
 }
 
-// Sleep specify sleep seconds after last action
+// Sleep specify sleep seconds after the end of last action
 func (s *StepMobile) Sleep(n float64) *StepMobile {
 	s.mobileStep().Actions = append(s.mobileStep().Actions, uixt.MobileAction{
 		Method:  uixt.ACTION_Sleep,
+		Params:  n,
+		Options: nil,
+	})
+	return &StepMobile{step: s.step}
+}
+
+// Sleep specify sleep seconds after the start of last action
+// if n > actual process time of last action (t), sleep (n-t) seconds
+// if n < actual process time of last action, skip sleep
+func (s *StepMobile) SleepStrict(n float64) *StepMobile {
+	s.mobileStep().Actions = append(s.mobileStep().Actions, uixt.MobileAction{
+		Method:  uixt.ACTION_SleepStrict,
 		Params:  n,
 		Options: nil,
 	})


### PR DESCRIPTION
## Main Changes
- feat: add `sleep_strcit` to sleep n seconds after the start of last action
- change: `GenNameWithTimestamp` return timestamp of length 13
- change: `MobileAction` adopts old data structure

## TestCases

running results of `demo_android_naive_sleep.json` and `demo_android_strict_sleep.json`

![image](https://github.com/httprunner/httprunner/assets/41049280/e3a22c9d-9baa-4008-8284-860e7e7e1772)
