### PR TITLE
Chore dev

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - compatibility: support indicating options separately in MobileAction level
 - fix: add default `regex`, `max_retry_times`, `offset`, `interval` for `swipe_to_tap_app` action
 - fix: ocr texts validation distinguishes `exists` from `equal`
+- fix: use Override size if existed, otherwise use Physical size
 
 ## v4.3.5 (2023-07-23)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fix: add default `regex`, `max_retry_times`, `offset`, `interval` for `swipe_to_tap_app` action
 - fix: ocr texts validation distinguishes `exists` from `equal`
 - fix: use Override size if existed, otherwise use Physical size
+- fix: empty request body during GetImage retry
 
 ## v4.3.5 (2023-07-23)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v4.3.6 (2023-07-24)
 
 - feat: support to reset driver (or session only) automatically when UIA2 / WDA crashed or WebDriver request failed
+- refactor: extract image_service.go from ocr_vedem.go
+- compatibility: support indicating options separately in MobileAction level
+- fix: add default `regex`, `max_retry_times`, `offset`, `interval` for `swipe_to_tap_app` action
+- fix: ocr texts validation distinguishes `exists` from `equal`
 
 ## v4.3.5 (2023-07-23)
 

--- a/hrp/pkg/uixt/action.go
+++ b/hrp/pkg/uixt/action.go
@@ -65,6 +65,16 @@ type MobileAction struct {
 	Method  ActionMethod   `json:"method,omitempty" yaml:"method,omitempty"`
 	Params  interface{}    `json:"params,omitempty" yaml:"params,omitempty"`
 	Options *ActionOptions `json:"options,omitempty" yaml:"options,omitempty"`
+	ActionOptions
+}
+
+func (ma MobileAction) GetOptions() []ActionOption {
+	var actionOptionList []ActionOption
+	if ma.Options != nil {
+		actionOptionList = append(actionOptionList, ma.Options.Options()...)
+	}
+	actionOptionList = append(actionOptionList, ma.ActionOptions.Options()...)
+	return actionOptionList
 }
 
 // (x1, y1) is the top left corner, (x2, y2) is the bottom right corner
@@ -403,19 +413,19 @@ func (dExt *DriverExt) DoAction(action MobileAction) error {
 			ACTION_AppLaunch, action.Params)
 	case ACTION_SwipeToTapApp:
 		if appName, ok := action.Params.(string); ok {
-			return dExt.swipeToTapApp(appName, action.Options.Options()...)
+			return dExt.swipeToTapApp(appName, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params, should be app name(string), got %v",
 			ACTION_SwipeToTapApp, action.Params)
 	case ACTION_SwipeToTapText:
 		if text, ok := action.Params.(string); ok {
-			return dExt.swipeToTapTexts([]string{text}, action.Options.Options()...)
+			return dExt.swipeToTapTexts([]string{text}, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params, should be app text(string), got %v",
 			ACTION_SwipeToTapText, action.Params)
 	case ACTION_SwipeToTapTexts:
 		if texts, ok := action.Params.([]string); ok {
-			return dExt.swipeToTapTexts(texts, action.Options.Options()...)
+			return dExt.swipeToTapTexts(texts, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params, should be app text([]string), got %v",
 			ACTION_SwipeToTapText, action.Params)
@@ -441,7 +451,7 @@ func (dExt *DriverExt) DoAction(action MobileAction) error {
 			}
 			x, _ := location[0].(float64)
 			y, _ := location[1].(float64)
-			return dExt.TapXY(x, y, action.Options.Options()...)
+			return dExt.TapXY(x, y, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params: %v", ACTION_TapXY, action.Params)
 	case ACTION_TapAbsXY:
@@ -452,22 +462,22 @@ func (dExt *DriverExt) DoAction(action MobileAction) error {
 			}
 			x, _ := location[0].(float64)
 			y, _ := location[1].(float64)
-			return dExt.TapAbsXY(x, y, action.Options.Options()...)
+			return dExt.TapAbsXY(x, y, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params: %v", ACTION_TapAbsXY, action.Params)
 	case ACTION_Tap:
 		if param, ok := action.Params.(string); ok {
-			return dExt.Tap(param, action.Options.Options()...)
+			return dExt.Tap(param, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params: %v", ACTION_Tap, action.Params)
 	case ACTION_TapByOCR:
 		if ocrText, ok := action.Params.(string); ok {
-			return dExt.TapByOCR(ocrText, action.Options.Options()...)
+			return dExt.TapByOCR(ocrText, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params: %v", ACTION_TapByOCR, action.Params)
 	case ACTION_TapByCV:
 		if imagePath, ok := action.Params.(string); ok {
-			return dExt.TapByCV(imagePath, action.Options.Options()...)
+			return dExt.TapByCV(imagePath, action.GetOptions()...)
 		}
 		return fmt.Errorf("invalid %s params: %v", ACTION_TapByCV, action.Params)
 	case ACTION_DoubleTapXY:
@@ -487,14 +497,14 @@ func (dExt *DriverExt) DoAction(action MobileAction) error {
 		}
 		return fmt.Errorf("invalid %s params: %v", ACTION_DoubleTap, action.Params)
 	case ACTION_Swipe:
-		swipeAction := dExt.prepareSwipeAction(action.Options.Options()...)
+		swipeAction := dExt.prepareSwipeAction(action.GetOptions()...)
 		return swipeAction(dExt)
 	case ACTION_Input:
 		// input text on current active element
 		// append \n to send text with enter
 		// send \b\b\b to delete 3 chars
 		param := fmt.Sprintf("%v", action.Params)
-		return dExt.Driver.Input(param, action.Options.Options()...)
+		return dExt.Driver.Input(param, action.GetOptions()...)
 	case ACTION_Back:
 		return dExt.Driver.PressBack()
 	case ACTION_Sleep:

--- a/hrp/pkg/uixt/android_adb_driver.go
+++ b/hrp/pkg/uixt/android_adb_driver.go
@@ -62,14 +62,20 @@ func (ad *adbDriver) WindowSize() (size Size, err error) {
 		return size, errors.Wrap(err, "get window size failed with adb")
 	}
 
-	// output may contain both Physical and Override size
+	// output may contain both Physical and Override size, use Override if existed
 	// Physical size: 1080x2340
 	// Override size: 1080x2220
+
+	var matchedSizeType = "Override"
+	if !strings.Contains(output, matchedSizeType) {
+		matchedSizeType = "Physical"
+	}
+
 	var resolution string
 	sizeList := strings.Split(output, "\n")
 	log.Info().Msgf("window size: %v", sizeList)
 	for _, size := range sizeList {
-		if strings.Contains(size, "Physical") {
+		if strings.Contains(size, matchedSizeType) {
 			resolution = strings.Split(size, ": ")[1]
 			// 1080x2340
 			ss := strings.Split(resolution, "x")
@@ -392,6 +398,7 @@ func (ad *adbDriver) StopCaptureLog() (result interface{}, err error) {
 		return "", err
 	}
 	content := ad.logcat.logBuffer.String()
+	log.Info().Str("logcat content", content).Msg("display logcat content")
 	return ConvertPoints(content), nil
 }
 

--- a/hrp/pkg/uixt/ext.go
+++ b/hrp/pkg/uixt/ext.go
@@ -253,8 +253,13 @@ func (dExt *DriverExt) FindUIRectInUIKit(search string, options ...ActionOption)
 	return dExt.FindImageRectInUIKit(search, options...)
 }
 
-func (dExt *DriverExt) IsOCRExist(text string) bool {
-	_, err := dExt.FindScreenText(text)
+func (dExt *DriverExt) IsOCRCorrect(text, assert string) bool {
+	var err error
+	if assert == AssertionEqual {
+		_, err = dExt.FindScreenText(text)
+		return err == nil
+	}
+	_, err = dExt.FindScreenText(text, WithRegex(true))
 	return err == nil
 }
 
@@ -273,7 +278,7 @@ func (dExt *DriverExt) DoValidation(check, assert, expected string, message ...s
 	var result bool
 	switch check {
 	case SelectorOCR:
-		result = (dExt.IsOCRExist(expected) == exp)
+		result = (dExt.IsOCRCorrect(expected, assert) == exp)
 	case SelectorImage:
 		result = (dExt.IsImageExist(expected) == exp)
 	case SelectorForegroundApp:

--- a/hrp/pkg/uixt/image_service.go
+++ b/hrp/pkg/uixt/image_service.go
@@ -1,0 +1,217 @@
+package uixt
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"image"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+
+	"github.com/httprunner/httprunner/v4/hrp/internal/builtin"
+	"github.com/httprunner/httprunner/v4/hrp/internal/code"
+	"github.com/httprunner/httprunner/v4/hrp/internal/env"
+)
+
+var client = &http.Client{
+	Timeout: time.Second * 10,
+}
+
+type ImageResult struct {
+	imagePath string
+	URL       string     `json:"url"`       // image uploaded url
+	OCRResult OCRResults `json:"ocrResult"` // OCR texts
+	LiveType  string     `json:"liveType"`  // 直播间类型
+}
+
+type APIResponseImage struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Result  ImageResult `json:"result"`
+}
+
+func newVEDEMImageService(actions ...string) (*veDEMImageService, error) {
+	if err := checkEnv(); err != nil {
+		return nil, err
+	}
+	if len(actions) == 0 {
+		actions = []string{"ocr"}
+	}
+	return &veDEMImageService{
+		actions: actions,
+	}, nil
+}
+
+// veDEMImageService implements IImageService interface
+// actions:
+// 	ocr - get ocr texts
+// 	upload - get image uploaded url
+// 	liveType - get live type
+// 	popup - get popup windows
+// 	close - get close popup
+type veDEMImageService struct {
+	actions []string
+}
+
+func (s *veDEMImageService) GetImage(imageBuf *bytes.Buffer) (
+	imageResult ImageResult, err error,
+) {
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+	for _, action := range s.actions {
+		bodyWriter.WriteField("actions", action)
+	}
+	bodyWriter.WriteField("ocrCluster", "highPrecision")
+
+	formWriter, err := bodyWriter.CreateFormFile("image", "screenshot.png")
+	if err != nil {
+		err = errors.Wrap(code.OCRRequestError,
+			fmt.Sprintf("create form file error: %v", err))
+		return
+	}
+
+	size, err := formWriter.Write(imageBuf.Bytes())
+	if err != nil {
+		err = errors.Wrap(code.OCRRequestError,
+			fmt.Sprintf("write form error: %v", err))
+		return
+	}
+
+	err = bodyWriter.Close()
+	if err != nil {
+		err = errors.Wrap(code.OCRRequestError,
+			fmt.Sprintf("close body writer error: %v", err))
+		return
+	}
+
+	req, err := http.NewRequest("POST", env.VEDEM_IMAGE_URL, bodyBuf)
+	if err != nil {
+		err = errors.Wrap(code.OCRRequestError,
+			fmt.Sprintf("construct request error: %v", err))
+		return
+	}
+
+	signToken := "UNSIGNED-PAYLOAD"
+	token := builtin.Sign("auth-v2", env.VEDEM_IMAGE_AK, env.VEDEM_IMAGE_SK, []byte(signToken))
+
+	req.Header.Add("Agw-Auth", token)
+	req.Header.Add("Agw-Auth-Content", signToken)
+	req.Header.Add("Content-Type", bodyWriter.FormDataContentType())
+
+	// ppe
+	// req.Header.Add("x-use-ppe", "1")
+	// req.Header.Add("x-tt-env", "ppe_vedem_algorithm")
+
+	var resp *http.Response
+	// retry 3 times
+	for i := 1; i <= 3; i++ {
+		start := time.Now()
+		resp, err = client.Do(req)
+		elapsed := time.Since(start)
+		var logID string
+		if resp != nil {
+			logID = getLogID(resp.Header)
+		}
+		if err == nil && resp.StatusCode == http.StatusOK {
+			log.Debug().
+				Str("X-TT-LOGID", logID).
+				Int("image_bytes", size).
+				Float64("elapsed(s)", elapsed.Seconds()).
+				Msg("request OCR service success")
+			break
+		}
+		log.Error().Err(err).
+			Str("X-TT-LOGID", logID).
+			Int("imageBufSize", size).
+			Msgf("request veDEM OCR service failed, retry %d", i)
+		time.Sleep(1 * time.Second)
+	}
+	if resp == nil {
+		err = code.OCRServiceConnectionError
+		return
+	}
+
+	defer resp.Body.Close()
+
+	results, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = errors.Wrap(code.OCRResponseError,
+			fmt.Sprintf("read response body error: %v", err))
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = errors.Wrap(code.OCRResponseError,
+			fmt.Sprintf("unexpected response status code: %d, results: %v",
+				resp.StatusCode, string(results)))
+		return
+	}
+
+	var imageResponse APIResponseImage
+	err = json.Unmarshal(results, &imageResponse)
+	if err != nil {
+		log.Error().Err(err).
+			Str("response", string(results)).
+			Msg("json unmarshal veDEM image response body failed")
+		err = errors.Wrap(code.OCRResponseError,
+			"json unmarshal veDEM image response body error")
+		return
+	}
+
+	if imageResponse.Code != 0 {
+		log.Error().
+			Int("code", imageResponse.Code).
+			Str("message", imageResponse.Message).
+			Msg("request veDEM OCR service failed")
+	}
+
+	imageResult = imageResponse.Result
+	log.Debug().Interface("imageResult", imageResult).Msg("get image data by veDEM")
+	return imageResult, nil
+}
+
+func checkEnv() error {
+	if env.VEDEM_IMAGE_URL == "" {
+		return errors.Wrap(code.OCREnvMissedError, "VEDEM_IMAGE_URL missed")
+	}
+	log.Info().Str("VEDEM_IMAGE_URL", env.VEDEM_IMAGE_URL).Msg("get env")
+	if env.VEDEM_IMAGE_AK == "" {
+		return errors.Wrap(code.OCREnvMissedError, "VEDEM_IMAGE_AK missed")
+	}
+	if env.VEDEM_IMAGE_SK == "" {
+		return errors.Wrap(code.OCREnvMissedError, "VEDEM_IMAGE_SK missed")
+	}
+	return nil
+}
+
+func getLogID(header http.Header) string {
+	if len(header) == 0 {
+		return ""
+	}
+
+	logID, ok := header["X-Tt-Logid"]
+	if !ok || len(logID) == 0 {
+		return ""
+	}
+	return logID[0]
+}
+
+type IImageService interface {
+	// GetImage returns image result including ocr texts, uploaded image url, etc
+	GetImage(imageBuf *bytes.Buffer) (imageResult ImageResult, err error)
+}
+
+func getRectangleCenterPoint(rect image.Rectangle) (point PointF) {
+	x, y := float64(rect.Min.X), float64(rect.Min.Y)
+	width, height := float64(rect.Dx()), float64(rect.Dy())
+	point = PointF{
+		X: x + width*0.5,
+		Y: y + height*0.5,
+	}
+	return point
+}

--- a/hrp/pkg/uixt/ocr_vedem.go
+++ b/hrp/pkg/uixt/ocr_vedem.go
@@ -4,24 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"image"
-	"io/ioutil"
-	"mime/multipart"
-	"net/http"
 	"regexp"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/httprunner/httprunner/v4/hrp/internal/builtin"
 	"github.com/httprunner/httprunner/v4/hrp/internal/code"
-	"github.com/httprunner/httprunner/v4/hrp/internal/env"
-	"github.com/httprunner/httprunner/v4/hrp/internal/json"
 )
-
-var client = &http.Client{
-	Timeout: time.Second * 10,
-}
 
 type OCRResult struct {
 	Text   string   `json:"text"`
@@ -50,19 +40,6 @@ func (o OCRResults) ToOCRTexts() (ocrTexts OCRTexts) {
 		ocrTexts = append(ocrTexts, ocrText)
 	}
 	return
-}
-
-type ImageResult struct {
-	imagePath string
-	URL       string     `json:"url"`       // image uploaded url
-	OCRResult OCRResults `json:"ocrResult"` // OCR texts
-	LiveType  string     `json:"liveType"`  // 直播间类型
-}
-
-type APIResponseImage struct {
-	Code    int         `json:"code"`
-	Message string      `json:"message"`
-	Result  ImageResult `json:"result"`
 }
 
 type OCRText struct {
@@ -104,8 +81,8 @@ func (t OCRTexts) FilterScope(scope AbsScope) (results OCRTexts) {
 }
 
 func (t OCRTexts) FindText(text string, options ...ActionOption) (
-	result OCRText, err error) {
-
+	result OCRText, err error,
+) {
 	actionOptions := NewActionOptions(options...)
 
 	var results []OCRText
@@ -146,7 +123,8 @@ func (t OCRTexts) FindText(text string, options ...ActionOption) (
 }
 
 func (t OCRTexts) FindTexts(texts []string, options ...ActionOption) (
-	results OCRTexts, err error) {
+	results OCRTexts, err error,
+) {
 	for _, text := range texts {
 		ocrText, err := t.FindText(text, options...)
 		if err != nil {
@@ -160,174 +138,6 @@ func (t OCRTexts) FindTexts(texts []string, options ...ActionOption) (
 			fmt.Sprintf("texts %s not found in %v", texts, t.texts()))
 	}
 	return results, nil
-}
-
-func newVEDEMImageService(actions ...string) (*veDEMImageService, error) {
-	if err := checkEnv(); err != nil {
-		return nil, err
-	}
-	if len(actions) == 0 {
-		actions = []string{"ocr"}
-	}
-	return &veDEMImageService{
-		actions: actions,
-	}, nil
-}
-
-// veDEMImageService implements IImageService interface
-// actions:
-//
-//	ocr - get ocr texts
-//	upload - get image uploaded url
-//	liveType - get live type
-//	popup - get popup windows
-//	close - get close popup
-type veDEMImageService struct {
-	actions []string
-}
-
-func (s *veDEMImageService) GetImage(imageBuf *bytes.Buffer) (
-	imageResult ImageResult, err error) {
-
-	bodyBuf := &bytes.Buffer{}
-	bodyWriter := multipart.NewWriter(bodyBuf)
-	for _, action := range s.actions {
-		bodyWriter.WriteField("actions", action)
-	}
-	bodyWriter.WriteField("ocrCluster", "highPrecision")
-
-	formWriter, err := bodyWriter.CreateFormFile("image", "screenshot.png")
-	if err != nil {
-		err = errors.Wrap(code.OCRRequestError,
-			fmt.Sprintf("create form file error: %v", err))
-		return
-	}
-
-	size, err := formWriter.Write(imageBuf.Bytes())
-	if err != nil {
-		err = errors.Wrap(code.OCRRequestError,
-			fmt.Sprintf("write form error: %v", err))
-		return
-	}
-
-	err = bodyWriter.Close()
-	if err != nil {
-		err = errors.Wrap(code.OCRRequestError,
-			fmt.Sprintf("close body writer error: %v", err))
-		return
-	}
-
-	req, err := http.NewRequest("POST", env.VEDEM_IMAGE_URL, bodyBuf)
-	if err != nil {
-		err = errors.Wrap(code.OCRRequestError,
-			fmt.Sprintf("construct request error: %v", err))
-		return
-	}
-
-	signToken := "UNSIGNED-PAYLOAD"
-	token := builtin.Sign("auth-v2", env.VEDEM_IMAGE_AK, env.VEDEM_IMAGE_SK, []byte(signToken))
-
-	req.Header.Add("Agw-Auth", token)
-	req.Header.Add("Agw-Auth-Content", signToken)
-	req.Header.Add("Content-Type", bodyWriter.FormDataContentType())
-
-	var resp *http.Response
-	// retry 3 times
-	for i := 1; i <= 3; i++ {
-		start := time.Now()
-		resp, err = client.Do(req)
-		elapsed := time.Since(start)
-		var logID string
-		if resp != nil {
-			logID = getLogID(resp.Header)
-		}
-		if err == nil && resp.StatusCode == http.StatusOK {
-			log.Debug().
-				Str("X-TT-LOGID", logID).
-				Int("image_bytes", size).
-				Float64("elapsed(s)", elapsed.Seconds()).
-				Msg("request OCR service success")
-			break
-		}
-		log.Error().Err(err).
-			Str("X-TT-LOGID", logID).
-			Int("imageBufSize", size).
-			Msgf("request veDEM OCR service failed, retry %d", i)
-		time.Sleep(1 * time.Second)
-	}
-	if resp == nil {
-		err = code.OCRServiceConnectionError
-		return
-	}
-
-	defer resp.Body.Close()
-
-	results, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		err = errors.Wrap(code.OCRResponseError,
-			fmt.Sprintf("read response body error: %v", err))
-		return
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		err = errors.Wrap(code.OCRResponseError,
-			fmt.Sprintf("unexpected response status code: %d, results: %v",
-				resp.StatusCode, string(results)))
-		return
-	}
-
-	var imageResponse APIResponseImage
-	err = json.Unmarshal(results, &imageResponse)
-	if err != nil {
-		log.Error().Err(err).
-			Str("response", string(results)).
-			Msg("json unmarshal veDEM image response body failed")
-		err = errors.Wrap(code.OCRResponseError,
-			"json unmarshal veDEM image response body error")
-		return
-	}
-
-	if imageResponse.Code != 0 {
-		log.Error().
-			Int("code", imageResponse.Code).
-			Str("message", imageResponse.Message).
-			Msg("request veDEM OCR service failed")
-	}
-
-	imageResult = imageResponse.Result
-	log.Debug().Interface("imageResult", imageResult).Msg("get image data by veDEM")
-	return imageResult, nil
-}
-
-func checkEnv() error {
-	if env.VEDEM_IMAGE_URL == "" {
-		return errors.Wrap(code.OCREnvMissedError, "VEDEM_IMAGE_URL missed")
-	}
-	log.Info().Str("VEDEM_IMAGE_URL", env.VEDEM_IMAGE_URL).Msg("get env")
-	if env.VEDEM_IMAGE_AK == "" {
-		return errors.Wrap(code.OCREnvMissedError, "VEDEM_IMAGE_AK missed")
-	}
-	if env.VEDEM_IMAGE_SK == "" {
-		return errors.Wrap(code.OCREnvMissedError, "VEDEM_IMAGE_SK missed")
-	}
-	return nil
-}
-
-func getLogID(header http.Header) string {
-	if len(header) == 0 {
-		return ""
-	}
-
-	logID, ok := header["X-Tt-Logid"]
-	if !ok || len(logID) == 0 {
-		return ""
-	}
-	return logID[0]
-}
-
-type IImageService interface {
-	// GetImage returns image result including ocr texts, uploaded image url, etc
-	GetImage(imageBuf *bytes.Buffer) (imageResult ImageResult, err error)
 }
 
 // GetScreenResult takes a screenshot, returns the image recognization result
@@ -389,14 +199,4 @@ func (dExt *DriverExt) FindScreenText(text string, options ...ActionOption) (poi
 	log.Info().Str("text", text).
 		Interface("point", point).Msgf("FindScreenText success")
 	return
-}
-
-func getRectangleCenterPoint(rect image.Rectangle) (point PointF) {
-	x, y := float64(rect.Min.X), float64(rect.Min.Y)
-	width, height := float64(rect.Dx()), float64(rect.Dy())
-	point = PointF{
-		X: x + width*0.5,
-		Y: y + height*0.5,
-	}
-	return point
 }


### PR DESCRIPTION
- refactor: extract image_service.go from ocr_vedem.go
- compatibility: support indicating options separately in MobileAction level
- fix: add default `regex`, `max_retry_times`, `offset`, `interval` for `swipe_to_tap_app` action
- fix: ocr texts validation distinguishes `exists` from `equal`
- fix: use Override size if existed, otherwise use Physical size
- fix: empty request body during GetImage retry