### PR TITLE
fix(loader): fix return nil when loader err

### DIFF
--- a/hrp/loader.go
+++ b/hrp/loader.go
@@ -53,7 +53,7 @@ func LoadTestCases(iTestCases ...ITestCase) ([]*TestCase, error) {
 			testCasePath := TestCasePath(path)
 			tc, err := testCasePath.ToTestCase()
 			if err != nil {
-				return nil
+				return err
 			}
 			testCases = append(testCases, tc)
 			return nil


### PR DESCRIPTION
修复文件加载报错返回值为 nil 的问题