### PR TITLE
fix: validateUI and FindTexts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat: support to reset driver (or session only) automatically when UIA2 / WDA crashed or WebDriver request failed
 - feat: `tap_cv` action supports ui type detection and tap
+- feat: enable uia2 driver if `log_on` is true for android devices
 - compatibility: support indicating options separately in `MobileAction` level
 - fix: use Override size if existed, otherwise use Physical size (android devices)
 - fix: add default options for `swipe_to_tap_app` action

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@
 - compatibility: support indicating options separately in `MobileAction` level
 - fix: use Override size if existed, otherwise use Physical size (android devices)
 - fix: add default options for `swipe_to_tap_app` action
-- refactor: ui validation methods
+- refactor: ui validation methods, support parsing expect value
 - fix: reuse the same request body during `GetImage` retry
 - change: upgrade funplugin to 0.5.2
 

--- a/hrp/pkg/uixt/action.go
+++ b/hrp/pkg/uixt/action.go
@@ -427,8 +427,18 @@ func (dExt *DriverExt) DoAction(action MobileAction) error {
 		if texts, ok := action.Params.([]string); ok {
 			return dExt.swipeToTapTexts(texts, action.GetOptions()...)
 		}
-		return fmt.Errorf("invalid %s params, should be app text([]string), got %v",
-			ACTION_SwipeToTapText, action.Params)
+		if iTexts, ok := action.Params.([]interface{}); ok {
+			var texts []string
+			for _, iText := range iTexts {
+				text, ok := iText.(string)
+				if !ok {
+					continue
+				}
+				texts = append(texts, text)
+			}
+			return dExt.swipeToTapTexts(texts, action.GetOptions()...)
+		}
+		return fmt.Errorf("invalid %s params: %v", ACTION_SwipeToTapTexts, action.Params)
 	case ACTION_AppTerminate:
 		if bundleId, ok := action.Params.(string); ok {
 			success, err := dExt.Driver.AppTerminate(bundleId)

--- a/hrp/pkg/uixt/android_adb_driver.go
+++ b/hrp/pkg/uixt/android_adb_driver.go
@@ -98,6 +98,10 @@ func (ad *adbDriver) Scale() (scale float64, err error) {
 	return 1, nil
 }
 
+func (ad *adbDriver) GetCachedScale() float64 {
+	return 1
+}
+
 func (ad *adbDriver) GetTimestamp() (timestamp int64, err error) {
 	// adb shell date +%s
 	output, err := ad.adbClient.RunShellCommand("date", "+%s")

--- a/hrp/pkg/uixt/android_device.go
+++ b/hrp/pkg/uixt/android_device.go
@@ -156,7 +156,7 @@ func (dev *AndroidDevice) LogEnabled() bool {
 
 func (dev *AndroidDevice) NewDriver(capabilities Capabilities) (driverExt *DriverExt, err error) {
 	var driver WebDriver
-	if dev.UIA2 {
+	if dev.UIA2 || dev.LogOn {
 		driver, err = dev.NewUSBDriver(capabilities)
 	} else {
 		driver, err = dev.NewAdbDriver()

--- a/hrp/pkg/uixt/interface.go
+++ b/hrp/pkg/uixt/interface.go
@@ -485,6 +485,7 @@ type WebDriver interface {
 	WindowSize() (Size, error)
 	Screen() (Screen, error)
 	Scale() (float64, error)
+	GetCachedScale() float64
 
 	// GetTimestamp returns the timestamp of the mobile device
 	GetTimestamp() (timestamp int64, err error)

--- a/hrp/pkg/uixt/ios_driver.go
+++ b/hrp/pkg/uixt/ios_driver.go
@@ -231,6 +231,10 @@ func (wd *wdaDriver) Scale() (float64, error) {
 	return screen.Scale, nil
 }
 
+func (wd *wdaDriver) GetCachedScale() float64 {
+	return wd.scale
+}
+
 func (wd *wdaDriver) toScale(x float64) float64 {
 	return x / wd.scale
 }

--- a/hrp/pkg/uixt/service_vedem.go
+++ b/hrp/pkg/uixt/service_vedem.go
@@ -144,6 +144,22 @@ func (t OCRTexts) FindText(text string, options ...ActionOption) (result OCRText
 	return results[idx], nil
 }
 
+func (t OCRTexts) FindTextsExisted(texts []string, options ...ActionOption) (results OCRTexts, err error) {
+	for _, text := range texts {
+		ocrText, err := t.FindText(text, options...)
+		if err != nil {
+			continue
+		}
+		results = append(results, ocrText)
+	}
+
+	if len(results) == 0 {
+		return nil, errors.Wrap(code.CVResultNotFoundError,
+			fmt.Sprintf("texts %s not found in %v", texts, t.texts()))
+	}
+	return results, nil
+}
+
 func (t OCRTexts) FindTexts(texts []string, options ...ActionOption) (results OCRTexts, err error) {
 	for _, text := range texts {
 		ocrText, err := t.FindText(text, options...)

--- a/hrp/pkg/uixt/service_vedem.go
+++ b/hrp/pkg/uixt/service_vedem.go
@@ -144,6 +144,7 @@ func (t OCRTexts) FindText(text string, options ...ActionOption) (result OCRText
 	return results[idx], nil
 }
 
+// FindTextsExisted returns if one of texts matched
 func (t OCRTexts) FindTextsExisted(texts []string, options ...ActionOption) (results OCRTexts, err error) {
 	for _, text := range texts {
 		ocrText, err := t.FindText(text, options...)
@@ -160,6 +161,7 @@ func (t OCRTexts) FindTextsExisted(texts []string, options ...ActionOption) (res
 	return results, nil
 }
 
+// FindTexts returns if all texts matched
 func (t OCRTexts) FindTexts(texts []string, options ...ActionOption) (results OCRTexts, err error) {
 	for _, text := range texts {
 		ocrText, err := t.FindText(text, options...)

--- a/hrp/pkg/uixt/swipe.go
+++ b/hrp/pkg/uixt/swipe.go
@@ -131,7 +131,7 @@ func (dExt *DriverExt) swipeToTapTexts(texts []string, options ...ActionOption) 
 	if len(texts) == 0 {
 		return errors.New("no text to tap")
 	}
-
+	options = append(options, WithMatchOne(true))
 	var point PointF
 	findTexts := func(d *DriverExt) error {
 		var err error
@@ -139,7 +139,7 @@ func (dExt *DriverExt) swipeToTapTexts(texts []string, options ...ActionOption) 
 		if err != nil {
 			return err
 		}
-		points, err := screenTexts.FindTextsExisted(texts, dExt.ParseActionOptions(options...)...)
+		points, err := screenTexts.FindTexts(texts, dExt.ParseActionOptions(options...)...)
 		if err != nil {
 			log.Error().Err(err).Msg("swipeToTapTexts failed")
 			// target texts not found, try to auto handle popup

--- a/hrp/pkg/uixt/swipe.go
+++ b/hrp/pkg/uixt/swipe.go
@@ -139,7 +139,7 @@ func (dExt *DriverExt) swipeToTapTexts(texts []string, options ...ActionOption) 
 		if err != nil {
 			return err
 		}
-		points, err := screenTexts.FindTexts(texts, dExt.ParseActionOptions(options...)...)
+		points, err := screenTexts.FindTextsExisted(texts, dExt.ParseActionOptions(options...)...)
 		if err != nil {
 			log.Error().Err(err).Msg("swipeToTapTexts failed")
 			// target texts not found, try to auto handle popup

--- a/hrp/pkg/uixt/tap.go
+++ b/hrp/pkg/uixt/tap.go
@@ -12,7 +12,7 @@ func (dExt *DriverExt) TapAbsXY(x, y float64, options ...ActionOption) error {
 func (dExt *DriverExt) TapXY(x, y float64, options ...ActionOption) error {
 	// tap on [x, y] percent of window size
 	if x > 1 || y > 1 {
-		return fmt.Errorf("x, y percentage should be < 1, got x=%v, y=%v", x, y)
+		return fmt.Errorf("x, y percentage should be <= 1, got x=%v, y=%v", x, y)
 	}
 
 	x = x * float64(dExt.windowSize.Width)

--- a/hrp/pkg/uixt/tap.go
+++ b/hrp/pkg/uixt/tap.go
@@ -15,8 +15,8 @@ func (dExt *DriverExt) TapXY(x, y float64, options ...ActionOption) error {
 		return fmt.Errorf("x, y percentage should be <= 1, got x=%v, y=%v", x, y)
 	}
 
-	x = x * float64(dExt.windowSize.Width)
-	y = y * float64(dExt.windowSize.Height)
+	x = x * float64(dExt.windowSize.Width) * dExt.Driver.GetCachedScale()
+	y = y * float64(dExt.windowSize.Height) * dExt.Driver.GetCachedScale()
 
 	return dExt.TapAbsXY(x, y, options...)
 }

--- a/hrp/response.go
+++ b/hrp/response.go
@@ -274,7 +274,7 @@ func (v *responseObject) searchRegexp(expr string) interface{} {
 	return expr
 }
 
-func validateUI(ud *uixt.DriverExt, iValidators []interface{}, parser *Parser, variablesMapping map[string]interface{}) (validateResults []*ValidationResult, err error) {
+func validateUI(ud *uixt.DriverExt, iValidators []interface{}) (validateResults []*ValidationResult, err error) {
 	for _, iValidator := range iValidators {
 		validator, ok := iValidator.(Validator)
 		if !ok {
@@ -294,12 +294,7 @@ func validateUI(ud *uixt.DriverExt, iValidators []interface{}, parser *Parser, v
 			continue
 		}
 
-		expectValue, err := parser.Parse(validator.Expect, variablesMapping)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse validator expect")
-		}
-
-		expected, ok := expectValue.(string)
+		expected, ok := validator.Expect.(string)
 		if !ok {
 			return nil, errors.New("validator expect should be string")
 		}

--- a/hrp/response.go
+++ b/hrp/response.go
@@ -274,7 +274,7 @@ func (v *responseObject) searchRegexp(expr string) interface{} {
 	return expr
 }
 
-func validateUI(ud *uixt.DriverExt, iValidators []interface{}) (validateResults []*ValidationResult, err error) {
+func validateUI(ud *uixt.DriverExt, iValidators []interface{}, parser *Parser, variablesMapping map[string]interface{}) (validateResults []*ValidationResult, err error) {
 	for _, iValidator := range iValidators {
 		validator, ok := iValidator.(Validator)
 		if !ok {
@@ -294,7 +294,12 @@ func validateUI(ud *uixt.DriverExt, iValidators []interface{}) (validateResults 
 			continue
 		}
 
-		expected, ok := validator.Expect.(string)
+		expectValue, err := parser.Parse(validator.Expect, variablesMapping)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse validator expect")
+		}
+
+		expected, ok := expectValue.(string)
 		if !ok {
 			return nil, errors.New("validator expect should be string")
 		}

--- a/hrp/runner.go
+++ b/hrp/runner.go
@@ -636,6 +636,23 @@ func (r *SessionRunner) ParseStepVariables(stepVariables map[string]interface{})
 	return parsedVariables, nil
 }
 
+func (r *SessionRunner) ParseStepValidators(iValidators []interface{}, stepVariables map[string]interface{}) ([]interface{}, error) {
+	var parsedValidators []interface{}
+	var err error
+	for _, iValidator := range iValidators {
+		validator, ok := iValidator.(Validator)
+		if !ok {
+			return nil, errors.New("validator type error")
+		}
+		validator.Expect, err = r.caseRunner.parser.Parse(validator.Expect, stepVariables)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse validator expect")
+		}
+		parsedValidators = append(parsedValidators, validator)
+	}
+	return parsedValidators, nil
+}
+
 // InitWithParameters updates session variables with given parameters.
 // this is used for data driven
 func (r *SessionRunner) InitWithParameters(parameters map[string]interface{}) {

--- a/hrp/step_mobile_ui.go
+++ b/hrp/step_mobile_ui.go
@@ -115,10 +115,10 @@ func (s *StepMobile) TapByOCR(ocrText string, options ...uixt.ActionOption) *Ste
 }
 
 // Tap taps on the target element by CV recognition
-func (s *StepMobile) TapByCV(imagePath string, options ...uixt.ActionOption) *StepMobile {
+func (s *StepMobile) TapByCV(cvInput interface{}, options ...uixt.ActionOption) *StepMobile {
 	action := uixt.MobileAction{
 		Method:  uixt.ACTION_TapByCV,
-		Params:  imagePath,
+		Params:  cvInput,
 		Options: uixt.NewActionOptions(options...),
 	}
 
@@ -660,7 +660,7 @@ func runStepMobileUI(s *SessionRunner, step *TStep) (stepResult *StepResult, err
 	}
 
 	// validate
-	validateResults, err := validateUI(uiDriver, step.Validators)
+	validateResults, err := validateUI(uiDriver, step.Validators, s.caseRunner.parser, stepVariables)
 	if err != nil {
 		if !code.IsErrorPredefined(err) {
 			err = errors.Wrap(code.MobileUIValidationError, err.Error())

--- a/hrp/step_mobile_ui.go
+++ b/hrp/step_mobile_ui.go
@@ -660,7 +660,11 @@ func runStepMobileUI(s *SessionRunner, step *TStep) (stepResult *StepResult, err
 	}
 
 	// validate
-	validateResults, err := validateUI(uiDriver, step.Validators, s.caseRunner.parser, stepVariables)
+	stepValidators, err := s.ParseStepValidators(step.Validators, stepVariables)
+	if err != nil {
+		return
+	}
+	validateResults, err := validateUI(uiDriver, stepValidators)
 	if err != nil {
 		if !code.IsErrorPredefined(err) {
 			err = errors.Wrap(code.MobileUIValidationError, err.Error())


### PR DESCRIPTION
# main changes
- feat: enable uia2 driver if `log_on` is true for android devices
- feat: `validateUI` supports parsing expect value
- fix: add `match_one` option for FindTexts method
- fix: iOS `tap_xy` scale adaption error