### PR TITLE
fix: iOS `tap_xy` scale adaption error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ UI related:
 - fix: use Override size if existed, otherwise use Physical size (android devices)
 - fix: add default options for `swipe_to_tap_app` action
 - fix: reuse the same request body during `GetImage` retry
+- fix: iOS `tap_xy` scale adaption error
 
 others:
 

--- a/hrp/internal/builtin/utils.go
+++ b/hrp/internal/builtin/utils.go
@@ -450,3 +450,8 @@ func GenNameWithTimestamp(tmpl string) string {
 	}
 	return fmt.Sprintf(tmpl, time.Now().Unix())
 }
+
+func IsZeroFloat64(f float64) bool {
+	threshold := 1e-3
+	return math.Abs(f) < threshold
+}

--- a/hrp/pkg/uixt/android_device.go
+++ b/hrp/pkg/uixt/android_device.go
@@ -161,7 +161,7 @@ func (dev *AndroidDevice) NewDriver(options ...DriverOption) (driverExt *DriverE
 	}
 
 	var driver WebDriver
-	if dev.UIA2 {
+	if dev.UIA2 || dev.LogOn {
 		driver, err = dev.NewUSBDriver(driverOptions.capabilities)
 	} else {
 		driver, err = dev.NewAdbDriver()

--- a/hrp/pkg/uixt/ios_driver.go
+++ b/hrp/pkg/uixt/ios_driver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
+	"github.com/httprunner/httprunner/v4/hrp/internal/builtin"
 	"github.com/httprunner/httprunner/v4/hrp/internal/code"
 	"github.com/httprunner/httprunner/v4/hrp/internal/json"
 	"github.com/httprunner/httprunner/v4/hrp/pkg/gidevice"
@@ -223,6 +224,9 @@ func (wd *wdaDriver) GetTimestamp() (timestamp int64, err error) {
 }
 
 func (wd *wdaDriver) Scale() (float64, error) {
+	if !builtin.IsZeroFloat64(wd.scale) {
+		return wd.scale, nil
+	}
 	screen, err := wd.Screen()
 	if err != nil {
 		return 0, errors.Wrap(code.MobileUIDriverError,

--- a/hrp/pkg/uixt/tap.go
+++ b/hrp/pkg/uixt/tap.go
@@ -12,11 +12,15 @@ func (dExt *DriverExt) TapAbsXY(x, y float64, options ...ActionOption) error {
 func (dExt *DriverExt) TapXY(x, y float64, options ...ActionOption) error {
 	// tap on [x, y] percent of window size
 	if x > 1 || y > 1 {
-		return fmt.Errorf("x, y percentage should be < 1, got x=%v, y=%v", x, y)
+		return fmt.Errorf("x, y percentage should be <= 1, got x=%v, y=%v", x, y)
 	}
 
-	x = x * float64(dExt.windowSize.Width)
-	y = y * float64(dExt.windowSize.Height)
+	scale, err := dExt.Driver.Scale()
+	if err != nil {
+		return fmt.Errorf("failed to get scale: %v", err)
+	}
+	x = x * float64(dExt.windowSize.Width) * scale
+	y = y * float64(dExt.windowSize.Height) * scale
 
 	return dExt.TapAbsXY(x, y, options...)
 }


### PR DESCRIPTION
# main changes
- fix: iOS `tap_xy` scale adaption error
- feat: enable uia2 driver if `log_on` is true for android devices