### PR TITLE
作者你好，python版增加自定义断言、json参数可整体用变量替换、csv中定义用例名，麻烦看下这样实现合理不

### DIFF
--- a/httprunner/response.py
+++ b/httprunner/response.py
@@ -45,8 +45,11 @@ def get_uniform_comparator(comparator: Text):
         "length_less_or_equals",
     ]:
         return "length_less_or_equals"
-    else:
+    elif comparator in ["contains", "contained_by", "type_match", "regex_match", "startswith", "endswith"]:
         return comparator
+    else:
+        return f"custom_{comparator}"
+
 
 
 def uniform_validator(validator):
@@ -201,6 +204,8 @@ class ResponseObjectBase(object):
 
             # comparator
             assert_method = u_validator["assert"]
+            if assert_method.startswith("custom"):
+                assert_method = assert_method.split("_", 1)[1]
             assert_func = self.parser.get_mapping_function(assert_method)
 
             # expect item

--- a/httprunner/step_request.py
+++ b/httprunner/step_request.py
@@ -119,7 +119,10 @@ def run_step_request(runner: HttpRunner, step: TStep) -> StepResult:
     url_path = parsed_request_dict.pop("url")
     url = build_url(config.base_url, url_path)
     parsed_request_dict["verify"] = config.verify
-    parsed_request_dict["json"] = parsed_request_dict.pop("req_json", {})
+    json_data = parsed_request_dict.pop("req_json", {})
+    if json_data and not (isinstance(json_data, dict) or isinstance(json_data, list)):
+        json_data = json.loads(json_data)
+    parsed_request_dict["json"] = json_data
 
     # log request
     request_print = "====== request details ======\n"

--- a/httprunner/step_request.py
+++ b/httprunner/step_request.py
@@ -335,6 +335,15 @@ class StepRequestValidation(IStep):
         )
         return self
 
+
+    def assert_custom(
+        self, custom_function: Text, jmes_path:Text,expected_value: Any, message: Text = ""
+    ) -> "StepRequestValidation":
+        self.__step.validators.append(
+            {custom_function: [jmes_path, expected_value, message]}
+        )
+        return self
+
     def struct(self) -> TStep:
         return self.__step
 


### PR DESCRIPTION
1.python版增加自定义断言，较复杂的响应结果校验用自定义断言，获取comparator的时候不是内置的断言函数则添加标识，make时根据标识生成不同的断言调用，执行断言的时候根据标识取出自定义方法；自定义断言方法需要是现在debugtalk中；
2.请求体json可以整体用变量替换，使用csv参数化的时候可以整个参数都放在了csv中；
3.使用csv文件参数化的时候增加自定义用例名，最后一列的名字（最后一列第一行）为ids时自动作为用例名，方便查看每组参数执行的什么场景；