### PR TITLE
add prometheus exporter api in master with new profile flag

### DIFF
--- a/hrp/boomer.go
+++ b/hrp/boomer.go
@@ -65,6 +65,9 @@ func (b *HRPBoomer) InitBoomer() {
 	if b.GetProfile().PrometheusPushgatewayURL != "" {
 		b.AddOutput(boomer.NewPrometheusPusherOutput(b.GetProfile().PrometheusPushgatewayURL, "hrp", b.GetMode()))
 	}
+	if b.GetProfile().PrometheusExporter {
+		b.SetExporterMode(true)
+	}
 	b.SetSpawnCount(b.GetProfile().SpawnCount)
 	b.SetSpawnRate(b.GetProfile().SpawnRate)
 	b.SetRunTime(b.GetProfile().RunTime)

--- a/hrp/cmd/boom.go
+++ b/hrp/cmd/boom.go
@@ -136,6 +136,7 @@ func init() {
 	boomCmd.Flags().StringVar(&boomArgs.CPUProfile, "cpu-profile", "", "Enable CPU profiling.")
 	boomCmd.Flags().DurationVar(&boomArgs.CPUProfileDuration, "cpu-profile-duration", 30*time.Second, "CPU profile duration.")
 	boomCmd.Flags().StringVar(&boomArgs.PrometheusPushgatewayURL, "prometheus-gateway", "", "Prometheus Pushgateway url.")
+	boomCmd.Flags().BoolVar(&boomArgs.PrometheusExporter, "prometheus-exporter", false, "Prometheus exporter api.")
 	boomCmd.Flags().BoolVar(&boomArgs.DisableConsoleOutput, "disable-console-output", false, "Disable console output.")
 	boomCmd.Flags().BoolVar(&boomArgs.DisableCompression, "disable-compression", false, "Disable compression")
 	boomCmd.Flags().BoolVar(&boomArgs.DisableKeepalive, "disable-keepalive", false, "Disable keepalive")

--- a/hrp/pkg/boomer/boomer.go
+++ b/hrp/pkg/boomer/boomer.go
@@ -538,7 +538,6 @@ func (b *Boomer) ReBalance(Args *Profile) error {
 
 // Stop stops to load test
 func (b *Boomer) Stop() error {
-	resetPrometheusMetrics()
 	return b.masterRunner.stop()
 }
 
@@ -634,6 +633,6 @@ func (b *Boomer) SetPrometheusMetrics() {
 		userCount += count
 	}
 	output.UserCount = userCount
-	setPrometheus(output)
+	setPrometheus(output, true)
 
 }

--- a/hrp/pkg/boomer/message.go
+++ b/hrp/pkg/boomer/message.go
@@ -8,6 +8,7 @@ const (
 	typeSpawningComplete = "spawning_complete"
 	typeQuit             = "quit"
 	typeException        = "exception"
+	typeStats            = "stats"
 )
 
 type genericMessage struct {

--- a/hrp/pkg/boomer/runner.go
+++ b/hrp/pkg/boomer/runner.go
@@ -353,7 +353,7 @@ func (r *runner) reportTestResult() {
 	currentTime := time.Now()
 	println(fmt.Sprint("=========================================== Statistics Summary =========================================="))
 	println(fmt.Sprintf("Current time: %s, Users: %v, Duration: %v, Accumulated Transactions: %d Passed, %d Failed",
-		currentTime.Format("2006/01/02 15:04:05"), r.controller.getCurrentClientsNum(), duration, r.stats.transactionPassed, r.stats.transactionFailed))
+		currentTime.Format("2006/01/02 15:04:05"), r.controller.getCurrentClientsNum(), duration, r.stats.transactionPassedForTestResult, r.stats.transactionFailedForTestResult))
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Name", "# requests", "# fails", "Median", "Average", "Min", "Max", "Content Size", "# reqs/sec", "# fails/sec"})
 	row := make([]string, 10)

--- a/hrp/pkg/boomer/stats.go
+++ b/hrp/pkg/boomer/stats.go
@@ -42,7 +42,7 @@ type requestStats struct {
 	requestSuccessChan chan *requestSuccess
 	requestFailureChan chan *requestFailure
 
-	messageToRunnerChan chan map[string]interface{}
+	statsToMasterChan chan map[string]interface{}
 }
 
 func newRequestStats() (stats *requestStats) {
@@ -56,7 +56,7 @@ func newRequestStats() (stats *requestStats) {
 	stats.transactionChan = make(chan *transaction, 100)
 	stats.requestSuccessChan = make(chan *requestSuccess, 100)
 	stats.requestFailureChan = make(chan *requestFailure, 100)
-	stats.messageToRunnerChan = make(chan map[string]interface{})
+	stats.statsToMasterChan = make(chan map[string]interface{})
 
 	stats.total = &statsEntry{
 		Name:   "Total",

--- a/hrp/pkg/boomer/stats.go
+++ b/hrp/pkg/boomer/stats.go
@@ -36,9 +36,11 @@ type requestStats struct {
 	totalForTestResult *statsEntry
 	startTime          int64
 
-	transactionChan   chan *transaction
-	transactionPassed int64 // accumulated number of passed transactions
-	transactionFailed int64 // accumulated number of failed transactions
+	transactionChan                chan *transaction
+	transactionPassed              int64 // accumulated number of passed transactions
+	transactionFailed              int64 // accumulated number of failed transactions
+	transactionPassedForTestResult int64 // accumulated number of passed transactions
+	transactionFailedForTestResult int64 // accumulated number of failed transactions
 
 	requestSuccessChan chan *requestSuccess
 	requestFailureChan chan *requestFailure
@@ -137,6 +139,7 @@ func (s *requestStats) clearAll() {
 	s.totalForTestResult.reset()
 	s.transactionPassed = 0
 	s.transactionFailed = 0
+	s.transactionPassedForTestResult, s.transactionFailedForTestResult = 0, 0
 	s.entries = make(map[string]*statsEntry)
 	s.errors = make(map[string]*statsError)
 	s.startTime = time.Now().Unix()
@@ -166,6 +169,8 @@ func (s *requestStats) collectReportData() map[string]interface{} {
 		"passed": s.transactionPassed,
 		"failed": s.transactionFailed,
 	}
+	s.transactionPassedForTestResult += s.transactionPassed
+	s.transactionFailedForTestResult += s.transactionFailed
 	data["stats"] = s.serializeStats()
 	s.totalForTestResult.extend(s.total)
 	data["stats_total"] = s.total.getStrippedReport()

--- a/hrp/server.go
+++ b/hrp/server.go
@@ -336,7 +336,7 @@ func (api *apiHandler) GetMasterInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (api *apiHandler) Metrics() http.HandlerFunc {
-	registry := boomer.GetRegistry()
+	registry := boomer.GetRegistry(true)
 	h := promhttp.InstrumentMetricHandler(
 		registry, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
 	)


### PR DESCRIPTION
子命令boom添加新的profile参数prometheus-exporter，当指定该参数时，worker开启定时上报stat消息（格式同为dataOutput），master汇聚stat消息（类似locust，提供Prometheus metric exporter的方式），提供/metric 接口暴露exporter给Prometheus抓取，本次提交主要为了提供多一种Prometheus数据汇聚的方式，原方式为push，现提供pull的方式。
添加新参数：
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/458b6fad-68cc-4241-b511-aa267af3d7a1">

metric exporter api：
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/c74150c2-6e04-41cb-afc9-dc792acd88b7">
